### PR TITLE
Phase 4b: AIRR/scverse contract adapter and tests

### DIFF
--- a/PHASE4B_NOTES.md
+++ b/PHASE4B_NOTES.md
@@ -1,0 +1,80 @@
+# Phase 4b AIRR/scverse contract — status and open interface assumptions
+
+Status: independent Phase 4b contract implemented and tested against synthetic
+objects and the local AP4 fixture. No public package/API created yet; this is
+internal groundwork to be integrated after Phase 4a lands.
+
+## What was delivered
+
+- `airr_adapter.py` — internal (pre-API) adapter:
+  - `select_heavy_chains` — deterministic one-heavy-chain-per-cell selection.
+  - `airr_to_dataframe` — flatten scirpy's ragged `obsm["airr"]` awkward array.
+  - `scirpy_primary_heavy_index` — read scirpy's `chain_indices.VDJ[0]` pointer.
+  - `to_r_barcode`/`from_r_barcode`/`assert_reversible_barcodes` — explicit,
+    reversible `-`<->`.` barcode join normalisation (never mutates the object).
+  - `build_encoder_input`/`write_encoder_input_csv` — AIRR -> encoder columns.
+  - `attach_embedding` — write embeddings into the AIRR modality obsm without
+    disturbing `airr`/`chain_indices`.
+  - `BenisseNetworkResult` + `validate_network_result` + `attach/read_network_result`
+    — clonotype-network result schema stored in `uns`, not cell-aligned `obsp`.
+  - `TEN_X_TO_AIRR`, `AIRR_TO_ENCODER` — documented field mappings.
+- `tests/test_airr_adapter.py` — 14 synthetic-object tests (always run).
+- `tests/test_airr_adapter_ap4.py` — 6 real-fixture parity tests (skip if the
+  gitignored fixture is absent).
+- `derive_ap4_encoder_input.py` — reproducible derivation of the encoder input
+  CSV from the AP4 fixture, writing to gitignored `data/external/` with a
+  provenance sidecar.
+
+## Verified facts (benisse-scirpy022 env, `python -m pytest -q`: 24 passed, 1 skipped)
+
+- Our independent heavy-chain ranking agrees with scirpy's `chain_indices`
+  primary VDJ pointer on **all 203** AP4 cells.
+- Derived counts match `data/manifest.yaml` `airr_summary`:
+  216 productive IGH with junction_aa, 214 unique, loci IGH/IGK/IGL =
+  233/138/121, 203 cells with a productive heavy chain.
+- Encoder `cdr3` <- AIRR `junction_aa` (keeps conserved C..W/F residues, matching
+  the committed `example/10x_NSCLC.csv`), NOT the narrower `cdr3_aa`.
+
+## Selection contract (deterministic)
+
+Candidate = `locus in {IGH}` AND non-empty `junction_aa` AND (`productive`).
+Rank per cell by: abundance count DESC, then `junction_aa` ASC, then
+`sequence_id` ASC. This is a total order, so the winner is independent of input
+chain order (tested). Abundance count coalesces `umi_count` -> `duplicate_count`
+-> `consensus_count` (AP4 has no `umi_count`).
+
+## Open interface assumptions — resolve during 4a integration
+
+1. **Adapter placement / public surface.** Currently a repo-root module imported
+   directly by tests (like `AchillesEncoder`). Phase 4e must decide whether it
+   moves into the `benisse/` package and what, if anything, becomes public API.
+2. **Heavy loci scope.** `HEAVY_LOCI = ("IGH",)` — BCR only. If TCR support is
+   ever in scope, extend to TRB/TRD and rename the "heavy" concept to "VDJ".
+3. **Count-field precedence.** Assumed `umi_count > duplicate_count >
+   consensus_count`. Matches scirpy on AP4, but confirm against the intended
+   Scirpy 0.24.0 pin (manifest `intended_scirpy_pin`), which may expose
+   `umi_count` directly and could change tie ordering.
+4. **Encoder identifier (`contigs`).** Mapped from AIRR `sequence_id` (unique per
+   selected chain). The legacy example used the 10x `contig_id`, which scirpy
+   also stores as `sequence_id`, so this matches — but the encoder ignores this
+   column at read time (`CMC/data_pre.py` reads only `contigs`,`cdr3`); it only
+   matters for the barcode<->chain<->embedding join, which lives in the adapter.
+5. **Barcode reversibility precondition.** `-`<->`.` normalisation is only
+   reversible when barcodes contain no `.`. True for AP4; `assert_reversible_barcodes`
+   guards it. A dataset with dotted barcodes needs a different join key.
+6. **Result-schema node identity.** `BenisseNetworkResult.node_ids` are the
+   encoder `contigs` (one per selected heavy chain). When the R core actually
+   produces `sparse_graph.txt` (Phase 4c/4d), confirm its node ordering maps 1:1
+   to this node index before populating `edges`. The schema is defined and
+   validated but not yet wired to real R output.
+7. **Embedding obsm alignment.** `attach_embedding` writes a cell-aligned matrix
+   into the `airr` modality with NaN rows for cells lacking a heavy chain. If the
+   canonical API instead stores a chain-level (not cell-level) object, the
+   alignment contract must be restated. Documented per airr_context.md.
+8. **MuData-vs-AnnData input.** The adapter duck-types both. Whether the public
+   entry point accepts both or MuData-only (airr_context.md "Open checks") is
+   still undecided.
+9. **Licence gate on derived data.** Derived receptor CSVs are written to
+   gitignored `data/external/` only; do not commit them until the processed
+   Stephenson dataset's redistribution licence is confirmed
+   (`manifest.license.processed_dataset: pending_verification`).

--- a/airr_adapter.py
+++ b/airr_adapter.py
@@ -1,0 +1,472 @@
+"""Phase 4b AIRR/scverse contract adapter for Benisse (INTERNAL, PRE-API).
+
+This module is the boundary between an AIRR/scverse object (a scirpy-style
+``AnnData`` with ``obsm["airr"]``, or a ``MuData`` with an ``airr`` modality) and
+the legacy Benisse encoder input contract. It is deliberately *not* a public
+package or a stable API: it exists so Phase 4b behaviour (deterministic
+heavy-chain selection, barcode joining, field mapping, MuData/AnnData
+preservation, and the clonotype-network result schema) can be defined and tested
+independently of Phase 4a, and later promoted into the package during Phase 4e.
+
+Scope decisions (see ``airr_context.md`` and ``UPDATE_PLAN.md`` Phase 4b):
+
+* AIRR Standards 2.0 field names at the receptor-data boundary.
+* Scirpy's in-memory representation is the source object; we never invent a
+  second AIRR container.
+* Cell barcodes (AIRR ``cell_id``) stay canonical. Any normalisation needed to
+  join to an R-style expression table (``-`` -> ``.``) is explicit and
+  reversible, never an in-place mutation of the object.
+* The encoder consumes only two columns, ``contigs`` (a unique per-chain id) and
+  ``cdr3`` (the heavy-chain junction amino-acid sequence). See
+  ``CMC/data_pre.py:load_BCRdata2`` which reads ``f[['contigs','cdr3']]``.
+
+Runtime deps: numpy, pandas, awkward, scipy. AnnData/MuData are only needed by
+callers that pass those objects; this module accepts either the container or its
+raw ``obsm['airr']`` awkward array so it can be unit-tested cheaply.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+import awkward as ak
+import numpy as np
+import pandas as pd
+
+SCHEMA_VERSION = "benisse-airr-0.1"
+
+# --- Field mappings -------------------------------------------------------
+
+#: 10x Cell Ranger contig column -> AIRR 2.0 field. Matches scirpy's
+#: ``read_10x_vdj`` mapping (airr_context.md). Kept for documentation and for a
+#: future raw-10x ingress path; the scverse objects we read are already AIRR.
+TEN_X_TO_AIRR: dict[str, str] = {
+    "barcode": "cell_id",
+    "contig_id": "sequence_id",
+    "chain": "locus",
+    "cdr3_nt": "junction",
+    "cdr3": "junction_aa",
+    "v_gene": "v_call",
+    "d_gene": "d_call",
+    "j_gene": "j_call",
+    "c_gene": "c_call",
+    "umis": "umi_count",
+    "reads": "consensus_count",
+    "productive": "productive",
+}
+
+#: AIRR field -> encoder input column. The encoder only reads these two.
+AIRR_TO_ENCODER: dict[str, str] = {
+    "sequence_id": "contigs",
+    "junction_aa": "cdr3",
+}
+
+#: Loci treated as the "heavy" / VDJ chain for BCR data. Benisse embeds the
+#: heavy-chain CDR3H only. (TCR beta/delta would extend this; recorded as an
+#: open assumption rather than silently supported.)
+HEAVY_LOCI: tuple[str, ...] = ("IGH",)
+
+#: Count fields used as chain-abundance evidence for ranking, best first.
+#: The Stephenson AP4 fixture stores ``duplicate_count``/``consensus_count`` and
+#: has no ``umi_count`` column, so we fall back across all three.
+COUNT_PREFERENCE: tuple[str, ...] = ("umi_count", "duplicate_count", "consensus_count")
+
+#: AIRR fields we surface from the ragged array (projected before flattening so
+#: awkward's unnamed index field and large alignment strings are skipped).
+_CHAIN_FIELDS: tuple[str, ...] = (
+    "locus",
+    "productive",
+    "junction_aa",
+    "junction",
+    "sequence_id",
+    "v_call",
+    "d_call",
+    "j_call",
+    "c_call",
+    "cdr3_aa",
+    "umi_count",
+    "duplicate_count",
+    "consensus_count",
+)
+
+
+# --- Awkward AIRR access --------------------------------------------------
+
+
+def _airr_array(obj: Any, modality: str = "airr") -> ak.Array:
+    """Return the ragged per-cell chain awkward array from a container/array.
+
+    Accepts a raw awkward array, an AnnData (uses ``obsm['airr']``), or a MuData
+    (uses ``mod[modality].obsm['airr']``). Duck-typed to avoid importing
+    anndata/mudata here.
+    """
+    if isinstance(obj, ak.Array):
+        return obj
+    # MuData: has ``.mod`` mapping of modalities.
+    mod = getattr(obj, "mod", None)
+    if isinstance(mod, Mapping) and modality in mod:
+        return mod[modality].obsm["airr"]
+    # AnnData: has ``.obsm``.
+    obsm = getattr(obj, "obsm", None)
+    if obsm is not None and "airr" in obsm:
+        return obsm["airr"]
+    raise TypeError(
+        "Expected an awkward array, an AnnData with obsm['airr'], or a MuData "
+        f"with a '{modality}' modality; got {type(obj)!r}."
+    )
+
+
+def _obs_names(obj: Any, modality: str = "airr") -> list[str]:
+    """Cell barcodes (AIRR cell_id) aligned to the airr array rows."""
+    if isinstance(obj, ak.Array):
+        return [str(i) for i in range(len(obj))]
+    mod = getattr(obj, "mod", None)
+    if isinstance(mod, Mapping) and modality in mod:
+        return list(map(str, mod[modality].obs_names))
+    return list(map(str, obj.obs_names))
+
+
+def airr_to_dataframe(obj: Any, modality: str = "airr") -> pd.DataFrame:
+    """Flatten the ragged AIRR array into one row per chain.
+
+    Columns: ``cell_id``, ``chain_pos`` (0-based position within the cell), and
+    every field in :data:`_CHAIN_FIELDS` that the object actually carries. The
+    result is deterministic: cell order follows ``obs_names`` and chain order
+    follows storage order within each cell.
+    """
+    airr = _airr_array(obj, modality)
+    cell_ids = _obs_names(obj, modality)
+    present = [f for f in _CHAIN_FIELDS if f in airr.fields]
+    projected = airr[present] if present else airr
+    records = ak.to_list(projected)
+
+    rows: list[dict[str, Any]] = []
+    for cell_id, chains in zip(cell_ids, records):
+        for pos, chain in enumerate(chains):
+            row: dict[str, Any] = {"cell_id": cell_id, "chain_pos": pos}
+            for f in present:
+                row[f] = chain.get(f)
+            rows.append(row)
+    columns = ["cell_id", "chain_pos", *present]
+    return pd.DataFrame(rows, columns=columns)
+
+
+# --- Deterministic heavy-chain selection ----------------------------------
+
+
+def _count_series(frame: pd.DataFrame) -> pd.Series:
+    """Chain-abundance evidence, coalescing the preferred count fields."""
+    result = pd.Series(0.0, index=frame.index)
+    have_value = pd.Series(False, index=frame.index)
+    for name in COUNT_PREFERENCE:
+        if name not in frame.columns:
+            continue
+        col = pd.to_numeric(frame[name], errors="coerce")
+        take = (~have_value) & col.notna()
+        result = result.mask(take, col)
+        have_value = have_value | col.notna()
+    return result.fillna(0.0)
+
+
+def select_heavy_chains(
+    obj: Any,
+    modality: str = "airr",
+    heavy_loci: Sequence[str] = HEAVY_LOCI,
+    require_productive: bool = True,
+) -> pd.DataFrame:
+    """Pick exactly one heavy chain per cell, deterministically.
+
+    A candidate chain must have ``locus`` in *heavy_loci*, a non-empty
+    ``junction_aa``, and (when *require_productive*) ``productive`` truthy.
+    Candidates are ranked per cell by descending abundance count, then ascending
+    ``junction_aa``, then ascending ``sequence_id`` -- a total order, so the
+    winner never depends on input row order. Cells with no candidate are
+    dropped.
+
+    Returns a DataFrame indexed by ``cell_id`` (unique) with the selected
+    chain's fields plus a ``selection_count`` column recording the abundance
+    value used. Row order follows the object's cell order.
+    """
+    chains = airr_to_dataframe(obj, modality)
+    if chains.empty:
+        return chains.set_index("cell_id") if "cell_id" in chains else chains
+
+    cand = chains[chains["locus"].isin(list(heavy_loci))].copy()
+    ja = cand["junction_aa"].astype("string")
+    cand = cand[ja.notna() & (ja.str.len() > 0)]
+    if require_productive:
+        cand = cand[cand["productive"].fillna(False).astype(bool)]
+
+    if cand.empty:
+        return pd.DataFrame(columns=chains.columns.drop("cell_id")).rename_axis("cell_id")
+
+    cand["selection_count"] = _count_series(cand)
+    # Preserve original cell order for a stable output row order.
+    cell_order = {cid: i for i, cid in enumerate(dict.fromkeys(chains["cell_id"]))}
+    cand["_cell_order"] = cand["cell_id"].map(cell_order)
+    cand["_ja"] = cand["junction_aa"].astype(str)
+    cand["_sid"] = cand["sequence_id"].astype(str)
+
+    cand = cand.sort_values(
+        by=["_cell_order", "selection_count", "_ja", "_sid"],
+        ascending=[True, False, True, True],
+        kind="mergesort",
+    )
+    winners = cand.drop_duplicates("cell_id", keep="first")
+    winners = winners.drop(columns=["_cell_order", "_ja", "_sid", "chain_pos"])
+    return winners.set_index("cell_id")
+
+
+def scirpy_primary_heavy_index(obj: Any, modality: str = "airr") -> "pd.Series | None":
+    """Scirpy's own primary heavy-chain pointer, if the object carries it.
+
+    Returns a Series (index = cell_id) of the ``VDJ[0]`` chain position from
+    ``obsm['chain_indices']``, or ``None`` when the object has no such array
+    (e.g. a hand-built synthetic object). Used to cross-check that our
+    independent ranking agrees with the ecosystem's deterministic selection.
+    """
+    if isinstance(obj, ak.Array):
+        return None
+    mod = getattr(obj, "mod", None)
+    if isinstance(mod, Mapping) and modality in mod:
+        adata = mod[modality]
+    else:
+        adata = obj
+    obsm = getattr(adata, "obsm", None)
+    if obsm is None or "chain_indices" not in obsm:
+        return None
+    ci = obsm["chain_indices"]
+    vdj0 = ak.to_list(ci["VDJ"][:, 0])
+    cell_ids = _obs_names(obj, modality)
+    return pd.Series(vdj0, index=pd.Index(cell_ids, name="cell_id"), name="vdj0")
+
+
+# --- Barcode joining ------------------------------------------------------
+
+
+def to_r_barcode(barcode: str) -> str:
+    """Normalise a canonical AIRR cell_id to the R-expression-table style.
+
+    ``R/prepare.R`` replaces ``-`` with ``.`` to match its expression columns.
+    This is reversible only when the barcode contains no ``.`` already; use
+    :func:`assert_reversible_barcodes` to guard a batch before relying on it.
+    """
+    return barcode.replace("-", ".")
+
+
+def from_r_barcode(barcode: str) -> str:
+    """Inverse of :func:`to_r_barcode` (``.`` -> ``-``)."""
+    return barcode.replace(".", "-")
+
+
+def assert_reversible_barcodes(barcodes: Iterable[str]) -> None:
+    """Raise if ``-``<->``.`` normalisation would not round-trip or would collide.
+
+    Guards two failure modes: a pre-existing ``.`` (which breaks the inverse)
+    and normalised collisions (two distinct barcodes mapping to one).
+    """
+    barcodes = list(barcodes)
+    with_dot = [b for b in barcodes if "." in b]
+    if with_dot:
+        raise ValueError(
+            f"{len(with_dot)} barcode(s) already contain '.', so '-'<->'.' "
+            f"normalisation is not reversible (e.g. {with_dot[0]!r})."
+        )
+    normalised = [to_r_barcode(b) for b in barcodes]
+    if len(set(normalised)) != len(set(barcodes)):
+        raise ValueError("R-style barcode normalisation is not injective on this set.")
+    for original in barcodes:
+        if from_r_barcode(to_r_barcode(original)) != original:
+            raise ValueError(f"Barcode {original!r} does not round-trip through R style.")
+
+
+# --- Encoder input --------------------------------------------------------
+
+
+def build_encoder_input(heavy: pd.DataFrame) -> pd.DataFrame:
+    """Turn selected heavy chains into the encoder's input table.
+
+    The returned frame is indexed by the canonical cell barcode and has exactly
+    the two columns the encoder reads: ``contigs`` (<- ``sequence_id``) and
+    ``cdr3`` (<- ``junction_aa``). Written with ``index=True`` this reproduces
+    the committed example layout (``,contigs,cdr3``).
+    """
+    if heavy.index.name != "cell_id":
+        raise ValueError("Expected select_heavy_chains() output indexed by cell_id.")
+    out = pd.DataFrame(
+        {
+            "contigs": heavy["sequence_id"].astype(str).to_numpy(),
+            "cdr3": heavy["junction_aa"].astype(str).to_numpy(),
+        },
+        index=heavy.index.rename("barcode"),
+    )
+    return out
+
+
+def write_encoder_input_csv(heavy: pd.DataFrame, path) -> pd.DataFrame:
+    """Write :func:`build_encoder_input` output to ``path`` and return it."""
+    table = build_encoder_input(heavy)
+    table.to_csv(path)
+    return table
+
+
+# --- Embedding preservation ----------------------------------------------
+
+
+def attach_embedding(
+    obj: Any,
+    embedding: pd.DataFrame,
+    modality: str = "airr",
+    key: str = "X_benisse",
+) -> Any:
+    """Write a per-cell embedding into the AIRR modality without harming it.
+
+    *embedding* is indexed by cell_id with one column per latent dimension. Rows
+    are aligned to the modality's ``obs_names``; cells absent from *embedding*
+    (e.g. no heavy chain) get an all-NaN row so the array stays cell-aligned.
+    The existing ``obsm['airr']`` and ``obsm['chain_indices']`` are asserted to
+    be untouched. Mutates and returns *obj*.
+    """
+    mod = getattr(obj, "mod", None)
+    adata = mod[modality] if isinstance(mod, Mapping) and modality in mod else obj
+    cell_ids = list(map(str, adata.obs_names))
+
+    before_fields = list(adata.obsm["airr"].fields)
+    before_len = len(adata.obsm["airr"])
+
+    aligned = embedding.reindex(cell_ids)
+    matrix = aligned.to_numpy(dtype="float64")
+    if matrix.shape[0] != len(cell_ids):
+        raise AssertionError("Embedding row count does not match obs_names.")
+    adata.obsm[key] = matrix
+
+    assert list(adata.obsm["airr"].fields) == before_fields, "AIRR fields mutated"
+    assert len(adata.obsm["airr"]) == before_len, "AIRR row count mutated"
+    if "chain_indices" in adata.obsm:
+        assert len(adata.obsm["chain_indices"]) == before_len, "chain_indices mutated"
+    return obj
+
+
+# --- Clonotype-network result schema --------------------------------------
+
+
+@dataclass
+class BenisseNetworkResult:
+    """Benisse's scientific output: a sparse graph over receptor nodes.
+
+    Benisse's object is a clonotype/receptor network, *not* a cell x cell
+    matrix, so it is stored with an explicit ``node_ids`` index rather than in a
+    cell-aligned ``obsp`` slot (airr_context.md). Edges are an explicit COO
+    triple (``row``, ``col``, ``weight``) indexing into ``node_ids``.
+
+    ``node_ids`` are the encoder ``contigs`` used as graph nodes (one per
+    selected heavy chain). ``params`` and ``provenance`` carry the R/model
+    parameters, input hashes, and schema identity needed to reproduce the run.
+    """
+
+    node_ids: list[str]
+    row: np.ndarray
+    col: np.ndarray
+    weight: np.ndarray
+    params: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+    schema_version: str = SCHEMA_VERSION
+
+    @property
+    def n_nodes(self) -> int:
+        return len(self.node_ids)
+
+    @property
+    def n_edges(self) -> int:
+        return int(len(self.row))
+
+    def to_coo(self):
+        from scipy.sparse import coo_matrix
+
+        n = self.n_nodes
+        return coo_matrix(
+            (np.asarray(self.weight, dtype="float64"),
+             (np.asarray(self.row, dtype="int64"), np.asarray(self.col, dtype="int64"))),
+            shape=(n, n),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "node_ids": list(self.node_ids),
+            "edges": {
+                "row": np.asarray(self.row, dtype="int64"),
+                "col": np.asarray(self.col, dtype="int64"),
+                "weight": np.asarray(self.weight, dtype="float64"),
+            },
+            "params": self.params,
+            "provenance": self.provenance,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "BenisseNetworkResult":
+        edges = data["edges"]
+        return cls(
+            node_ids=list(data["node_ids"]),
+            row=np.asarray(edges["row"], dtype="int64"),
+            col=np.asarray(edges["col"], dtype="int64"),
+            weight=np.asarray(edges["weight"], dtype="float64"),
+            params=dict(data.get("params", {})),
+            provenance=dict(data.get("provenance", {})),
+            schema_version=data.get("schema_version", SCHEMA_VERSION),
+        )
+
+
+def validate_network_result(result: BenisseNetworkResult) -> None:
+    """Raise ``ValueError`` if *result* is not a well-formed network."""
+    n = result.n_nodes
+    if len(set(result.node_ids)) != n:
+        raise ValueError("node_ids must be unique.")
+    lengths = {len(result.row), len(result.col), len(result.weight)}
+    if len(lengths) != 1:
+        raise ValueError("row, col, and weight must have equal length.")
+    if result.n_edges:
+        for name, arr in (("row", result.row), ("col", result.col)):
+            arr = np.asarray(arr)
+            if arr.min() < 0 or arr.max() >= n:
+                raise ValueError(f"{name} index out of range for {n} nodes.")
+    if result.schema_version != SCHEMA_VERSION:
+        raise ValueError(
+            f"Unexpected schema_version {result.schema_version!r}; "
+            f"expected {SCHEMA_VERSION!r}."
+        )
+
+
+def attach_network_result(
+    obj: Any, result: BenisseNetworkResult, uns_key: str = "benisse"
+) -> Any:
+    """Store *result* under ``uns[uns_key]['clonotype_network']``.
+
+    Deliberately uses ``uns`` (a free-form slot) with an explicit node index,
+    never a cell-aligned ``obsp``, because the network's nodes are receptors,
+    not the object's cells. Mutates and returns *obj*.
+    """
+    validate_network_result(result)
+    block = obj.uns.get(uns_key, {})
+    if not isinstance(block, dict):
+        block = {}
+    block["clonotype_network"] = result.to_dict()
+    block["schema_version"] = result.schema_version
+    obj.uns[uns_key] = block
+    return obj
+
+
+def read_network_result(
+    obj: Any, uns_key: str = "benisse"
+) -> BenisseNetworkResult:
+    """Inverse of :func:`attach_network_result`."""
+    block = obj.uns[uns_key]["clonotype_network"]
+    return BenisseNetworkResult.from_dict(block)
+
+
+def benisse_provenance(**items: Any) -> dict[str, Any]:
+    """Build a JSON-serialisable provenance dict, rejecting non-serialisable values."""
+    json.dumps(items)  # fail fast if a caller passes something unserialisable
+    return dict(items)

--- a/derive_ap4_encoder_input.py
+++ b/derive_ap4_encoder_input.py
@@ -1,0 +1,81 @@
+"""Reproducibly derive the Benisse encoder input from the AP4 AIRR fixture.
+
+Phase 4b groundwork script. Reads the deterministic 203-cell Stephenson AP4
+MuData fixture (recorded in ``data/manifest.yaml``, kept out of Git), applies
+:func:`airr_adapter.select_heavy_chains`, and writes the two-column encoder
+input CSV (``barcode,contigs,cdr3``) plus a JSON provenance sidecar with row
+counts and a SHA-256 of the CSV.
+
+The output goes under ``data/external/`` (gitignored) by default: the processed
+Stephenson dataset's redistribution licence is still ``pending_verification`` in
+the manifest, so derived receptor sequences must not be committed. Regenerate on
+demand from the local fixture instead.
+
+Usage (from repo root, in the benisse-scirpy022 env):
+
+    python derive_ap4_encoder_input.py \
+        --fixture data/external/stephenson2021_ap4_203.h5mu \
+        --out data/external/ap4_encoder_input.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import airr_adapter as aa
+
+DEFAULT_FIXTURE = Path("data/external/stephenson2021_ap4_203.h5mu")
+DEFAULT_OUT = Path("data/external/ap4_encoder_input.csv")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def derive(fixture: Path, out: Path) -> dict:
+    import mudata
+
+    mdata = mudata.read_h5mu(fixture)
+    heavy = aa.select_heavy_chains(mdata)
+    aa.assert_reversible_barcodes(heavy.index)
+    table = aa.write_encoder_input_csv(heavy, out)
+
+    provenance = {
+        "schema_version": aa.SCHEMA_VERSION,
+        "source_fixture": str(fixture),
+        "selection": "productive IGH, ranked by abundance then junction_aa then sequence_id",
+        "rows": int(len(table)),
+        "unique_junction_aa": int(table["cdr3"].nunique()),
+        "output_csv": str(out),
+        "output_sha256": _sha256(out),
+    }
+    sidecar = out.with_suffix(out.suffix + ".provenance.json")
+    sidecar.write_text(json.dumps(provenance, indent=2) + "\n")
+    return provenance
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+
+    if not args.fixture.exists():
+        raise SystemExit(
+            f"Fixture not found: {args.fixture}\n"
+            "It is gitignored; see data/manifest.yaml to reproduce it locally."
+        )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    provenance = derive(args.fixture, args.out)
+    print(json.dumps(provenance, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_airr_adapter.py
+++ b/tests/test_airr_adapter.py
@@ -1,0 +1,274 @@
+"""Phase 4b AIRR adapter tests on synthetic scverse objects.
+
+These never touch external data, so they always run. They pin the deterministic
+contract of ``airr_adapter``: heavy-chain selection and its tie-breaks, barcode
+join reversibility, encoder-input field mapping, embedding preservation, and the
+clonotype-network result schema. The AP4 fixture provides the real-object parity
+check separately (``test_airr_adapter_ap4.py``).
+"""
+
+import sys
+from pathlib import Path
+
+import awkward as ak
+import numpy as np
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import airr_adapter as aa  # noqa: E402
+
+anndata = pytest.importorskip("anndata")
+mudata = pytest.importorskip("mudata")
+
+
+# --- synthetic object builders -------------------------------------------
+
+_FIELDS = (
+    "locus",
+    "productive",
+    "junction_aa",
+    "sequence_id",
+    "duplicate_count",
+    "consensus_count",
+    "v_call",
+    "j_call",
+    "c_call",
+)
+
+
+def _chain(locus, junction_aa, sequence_id, productive=True, dup=1, cons=1,
+           v="IGHV1", j="IGHJ1", c="IGHM"):
+    return {
+        "locus": locus,
+        "productive": productive,
+        "junction_aa": junction_aa,
+        "sequence_id": sequence_id,
+        "duplicate_count": dup,
+        "consensus_count": cons,
+        "v_call": v,
+        "j_call": j,
+        "c_call": c,
+    }
+
+
+def _airr_anndata(cells):
+    """cells: list of (barcode, [chain dicts]) -> AnnData with obsm['airr']."""
+    barcodes = [b for b, _ in cells]
+    records = [chains for _, chains in cells]
+    airr = ak.Array(records)
+    adata = anndata.AnnData(np.zeros((len(barcodes), 0), dtype="float32"))
+    adata.obs_names = barcodes
+    adata.obsm["airr"] = airr
+    return adata
+
+
+# A: two IGH tie on count -> junction_aa breaks tie ("CARAA" < "CARWY").
+# B: productive IGH beats higher-count non-productive IGH.
+# C: light chains only -> dropped.
+# D: empty junction_aa IGH dropped in favour of the one with a junction.
+_CELLS = [
+    ("cell_A-1", [
+        _chain("IGH", "CARWY", "A_h1", dup=10, cons=100),
+        _chain("IGK", "CQQAA", "A_l1", dup=8, cons=80),
+        _chain("IGH", "CARAA", "A_h2", dup=10, cons=50),
+    ]),
+    ("cell_B-1", [
+        _chain("IGH", "CARBIG", "B_h_np", productive=False, dup=99, cons=99),
+        _chain("IGH", "CARSMALL", "B_h_ok", productive=True, dup=5, cons=5),
+    ]),
+    ("cell_C-1", [
+        _chain("IGK", "CQQCC", "C_l1", dup=7, cons=70),
+    ]),
+    ("cell_D-1", [
+        _chain("IGH", "", "D_h_empty", dup=50, cons=50),
+        _chain("IGH", "CARDD", "D_h_ok", dup=3, cons=3),
+    ]),
+]
+
+
+def test_heavy_selection_determinism_and_filters():
+    adata = _airr_anndata(_CELLS)
+    heavy = aa.select_heavy_chains(adata)
+
+    # cell_C has no heavy chain and is dropped; the rest each yield one row.
+    assert list(heavy.index) == ["cell_A-1", "cell_B-1", "cell_D-1"]
+    # Tie on count broken by ascending junction_aa.
+    assert heavy.loc["cell_A-1", "sequence_id"] == "A_h2"
+    assert heavy.loc["cell_A-1", "junction_aa"] == "CARAA"
+    # Productive filter beats raw abundance.
+    assert heavy.loc["cell_B-1", "sequence_id"] == "B_h_ok"
+    # Empty junction dropped.
+    assert heavy.loc["cell_D-1", "sequence_id"] == "D_h_ok"
+
+
+def test_heavy_selection_independent_of_chain_order():
+    forward = aa.select_heavy_chains(_airr_anndata(_CELLS))
+    reversed_cells = [(b, list(reversed(chains))) for b, chains in _CELLS]
+    backward = aa.select_heavy_chains(_airr_anndata(reversed_cells))
+    pd.testing.assert_frame_equal(forward, backward)
+
+
+def test_count_fallback_to_consensus_when_no_duplicate_count():
+    # Two productive IGH, equal on duplicate_count; consensus is only a later
+    # tiebreak, so junction_aa still decides here -- assert count coalescing
+    # picks duplicate_count first (both 4 -> tie -> junction_aa).
+    cells = [("z-1", [
+        _chain("IGH", "CARZB", "z2", dup=4, cons=999),
+        _chain("IGH", "CARZA", "z1", dup=4, cons=1),
+    ])]
+    heavy = aa.select_heavy_chains(_airr_anndata(cells))
+    assert heavy.loc["z-1", "sequence_id"] == "z1"  # CARZA < CARZB
+    assert heavy.loc["z-1", "selection_count"] == 4.0
+
+
+def test_scirpy_primary_heavy_index_reads_chain_indices():
+    adata = _airr_anndata(_CELLS[:1])
+    adata.obsm["chain_indices"] = ak.Array(
+        [{"VJ": [1, None], "VDJ": [0, None], "multichain": False}]
+    )
+    idx = aa.scirpy_primary_heavy_index(adata)
+    assert idx is not None
+    assert idx.loc["cell_A-1"] == 0
+
+
+def test_scirpy_primary_heavy_index_absent_returns_none():
+    assert aa.scirpy_primary_heavy_index(_airr_anndata(_CELLS)) is None
+
+
+# --- barcode joining ------------------------------------------------------
+
+
+def test_barcode_roundtrip():
+    bc = "S15_AAACGGGGTACAGTTC-1"
+    assert aa.to_r_barcode(bc) == "S15_AAACGGGGTACAGTTC.1"
+    assert aa.from_r_barcode(aa.to_r_barcode(bc)) == bc
+
+
+def test_barcode_reversibility_guard():
+    aa.assert_reversible_barcodes(["a-1", "b-2", "c_x-1"])
+    with pytest.raises(ValueError):
+        aa.assert_reversible_barcodes(["already.dotted-1"])
+    with pytest.raises(ValueError):
+        # "a.1" and "a-1" both normalise to "a.1" -> not injective.
+        aa.assert_reversible_barcodes(["a-1", "a.1"])
+
+
+# --- encoder input mapping ------------------------------------------------
+
+
+def test_build_encoder_input_columns_and_mapping():
+    heavy = aa.select_heavy_chains(_airr_anndata(_CELLS))
+    table = aa.build_encoder_input(heavy)
+    assert list(table.columns) == ["contigs", "cdr3"]
+    assert table.index.name == "barcode"
+    # contigs <- sequence_id, cdr3 <- junction_aa
+    assert table.loc["cell_A-1", "contigs"] == "A_h2"
+    assert table.loc["cell_A-1", "cdr3"] == "CARAA"
+
+
+def test_encoder_input_csv_layout_matches_example(tmp_path):
+    heavy = aa.select_heavy_chains(_airr_anndata(_CELLS))
+    path = tmp_path / "enc.csv"
+    aa.write_encoder_input_csv(heavy, path)
+    header = path.read_text().splitlines()[0]
+    assert header == "barcode,contigs,cdr3"  # same shape as example/10x_NSCLC.csv
+
+
+# --- embedding preservation ----------------------------------------------
+
+
+def test_attach_embedding_preserves_airr_and_aligns_rows():
+    adata = _airr_anndata(_CELLS)
+    heavy = aa.select_heavy_chains(adata)
+    emb = pd.DataFrame(
+        np.arange(len(heavy) * 3, dtype="float64").reshape(-1, 3),
+        index=heavy.index,
+    )
+    fields_before = list(adata.obsm["airr"].fields)
+
+    aa.attach_embedding(adata, emb, key="X_benisse")
+
+    assert adata.obsm["X_benisse"].shape == (adata.n_obs, 3)
+    assert list(adata.obsm["airr"].fields) == fields_before  # AIRR intact
+    # cell_C had no heavy chain -> its embedding row is all NaN.
+    c_pos = list(adata.obs_names).index("cell_C-1")
+    assert np.all(np.isnan(adata.obsm["X_benisse"][c_pos]))
+    a_pos = list(adata.obs_names).index("cell_A-1")
+    assert not np.any(np.isnan(adata.obsm["X_benisse"][a_pos]))
+
+
+def test_attach_embedding_on_mudata_leaves_gex_untouched():
+    airr_ad = _airr_anndata(_CELLS)
+    gex = anndata.AnnData(np.ones((airr_ad.n_obs, 4), dtype="float32"))
+    gex.obs_names = list(airr_ad.obs_names)
+    mdata = mudata.MuData({"gex": gex, "airr": airr_ad})
+
+    heavy = aa.select_heavy_chains(mdata)
+    emb = pd.DataFrame(np.ones((len(heavy), 2)), index=heavy.index)
+    aa.attach_embedding(mdata, emb, modality="airr", key="X_benisse")
+
+    assert "X_benisse" in mdata.mod["airr"].obsm
+    assert "X_benisse" not in mdata.mod["gex"].obsm
+    assert np.array_equal(mdata.mod["gex"].X, np.ones((airr_ad.n_obs, 4), dtype="float32"))
+
+
+# --- clonotype-network result schema -------------------------------------
+
+
+def _sample_result():
+    return aa.BenisseNetworkResult(
+        node_ids=["A_h2", "B_h_ok", "D_h_ok"],
+        row=np.array([0, 1]),
+        col=np.array([1, 2]),
+        weight=np.array([0.5, 0.9]),
+        params={"lambda": 1.0, "beta": 100},
+        provenance=aa.benisse_provenance(model="trained_model.pt", schema=aa.SCHEMA_VERSION),
+    )
+
+
+def test_network_result_roundtrip_and_coo():
+    res = _sample_result()
+    aa.validate_network_result(res)
+    coo = res.to_coo()
+    assert coo.shape == (3, 3)
+    assert coo.nnz == 2
+    assert coo.toarray()[0, 1] == 0.5
+
+    restored = aa.BenisseNetworkResult.from_dict(res.to_dict())
+    assert restored.node_ids == res.node_ids
+    assert np.array_equal(restored.weight, res.weight)
+
+
+def test_network_result_validation_errors():
+    dup = aa.BenisseNetworkResult(
+        node_ids=["x", "x"], row=np.array([], int), col=np.array([], int),
+        weight=np.array([], float),
+    )
+    with pytest.raises(ValueError):
+        aa.validate_network_result(dup)
+
+    oob = aa.BenisseNetworkResult(
+        node_ids=["x", "y"], row=np.array([0]), col=np.array([5]),
+        weight=np.array([1.0]),
+    )
+    with pytest.raises(ValueError):
+        aa.validate_network_result(oob)
+
+
+def test_attach_and_read_network_result_uses_uns_not_obsp():
+    adata = _airr_anndata(_CELLS)
+    res = _sample_result()
+    aa.attach_network_result(adata, res)
+
+    # Stored in uns with an explicit node index, never in cell-aligned obsp.
+    assert "clonotype_network" in adata.uns["benisse"]
+    assert len(adata.obsp) == 0
+
+    read = aa.read_network_result(adata)
+    assert read.node_ids == res.node_ids
+    assert np.array_equal(read.row, res.row)
+    assert read.params == res.params

--- a/tests/test_airr_adapter_ap4.py
+++ b/tests/test_airr_adapter_ap4.py
@@ -1,0 +1,109 @@
+"""Phase 4b parity checks against the real Stephenson AP4 MuData fixture.
+
+These run only when the gitignored fixture is present locally; otherwise they
+skip (CI has no access to it, and its redistribution licence is unconfirmed).
+They validate the adapter against the ecosystem's own object: our independent
+heavy-chain selection must agree with scirpy's ``chain_indices`` primary VDJ
+pointer, and the derived counts must match ``data/manifest.yaml``.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import airr_adapter as aa  # noqa: E402
+
+FIXTURE = REPO_ROOT / "data" / "external" / "stephenson2021_ap4_203.h5mu"
+
+mudata = pytest.importorskip("mudata")
+pytestmark = pytest.mark.skipif(
+    not FIXTURE.exists(), reason=f"AP4 fixture not present: {FIXTURE}"
+)
+
+
+@pytest.fixture(scope="module")
+def ap4():
+    return mudata.read_h5mu(FIXTURE)
+
+
+def test_selection_matches_manifest_shape(ap4):
+    heavy = aa.select_heavy_chains(ap4)
+    # manifest: cells_with_productive_heavy_and_light == 203
+    assert len(heavy) == 203
+    assert (heavy["locus"] == "IGH").all()
+    assert heavy["productive"].astype(bool).all()
+    assert heavy["junction_aa"].astype("string").notna().all()
+
+
+def test_selection_agrees_with_scirpy_primary_vdj(ap4):
+    """Our deterministic ranking == scirpy chain_indices VDJ[0] on every cell."""
+    heavy = aa.select_heavy_chains(ap4)
+    vdj0 = aa.scirpy_primary_heavy_index(ap4)
+    assert vdj0 is not None
+
+    airr = ap4.mod["airr"].obsm["airr"]
+    cell_ids = list(map(str, ap4.mod["airr"].obs_names))
+    pos_of = {cid: i for i, cid in enumerate(cell_ids)}
+
+    checked = 0
+    for cid in heavy.index:
+        pos = vdj0.loc[cid]
+        if pos is None or (isinstance(pos, float) and np.isnan(pos)):
+            continue
+        scirpy_seq = str(airr[pos_of[cid]][int(pos)]["sequence_id"])
+        assert heavy.loc[cid, "sequence_id"] == scirpy_seq
+        checked += 1
+    assert checked == 203
+
+
+def test_manifest_airr_summary_counts(ap4):
+    long = aa.airr_to_dataframe(ap4)
+    igh = long[long["locus"] == "IGH"]
+    prod = igh[
+        igh["productive"].fillna(False).astype(bool)
+        & igh["junction_aa"].astype("string").notna()
+    ]
+    # manifest airr_summary
+    assert len(prod) == 216  # productive_igh_with_junction_aa
+    assert prod["junction_aa"].nunique() == 214  # unique_productive_igh_junction_aa
+    assert long["locus"].value_counts().to_dict() == {"IGH": 233, "IGK": 138, "IGL": 121}
+
+
+def test_barcodes_are_r_join_reversible(ap4):
+    # Real barcodes (e.g. "S15_AAAC...-1") must survive '-'<->'.' normalisation.
+    aa.assert_reversible_barcodes(map(str, ap4.mod["airr"].obs_names))
+
+
+def test_encoder_input_maps_junction_aa_with_conserved_residues(ap4):
+    heavy = aa.select_heavy_chains(ap4)
+    table = aa.build_encoder_input(heavy)
+    assert list(table.columns) == ["contigs", "cdr3"]
+    # AIRR junction_aa keeps the conserved C..W/F boundary residues, matching the
+    # committed encoder example (e.g. "CAK...W"); it is NOT the narrower cdr3_aa.
+    assert (table["cdr3"].str.startswith("C")).mean() > 0.9
+    # contigs are the AIRR sequence_id (unique per selected chain).
+    assert table["contigs"].is_unique
+
+
+def test_embedding_write_preserves_airr_modality(ap4):
+    import pandas as pd
+
+    mdata = ap4  # module-scoped; we add a new obsm key without touching airr
+    heavy = aa.select_heavy_chains(mdata)
+    emb = pd.DataFrame(
+        np.zeros((len(heavy), 20), dtype="float64"), index=heavy.index
+    )
+    fields_before = list(mdata.mod["airr"].obsm["airr"].fields)
+    n_chain_idx = len(mdata.mod["airr"].obsm["chain_indices"])
+
+    aa.attach_embedding(mdata, emb, modality="airr", key="X_benisse_test")
+
+    assert mdata.mod["airr"].obsm["X_benisse_test"].shape == (mdata.n_obs, 20)
+    assert list(mdata.mod["airr"].obsm["airr"].fields) == fields_before
+    assert len(mdata.mod["airr"].obsm["chain_indices"]) == n_chain_idx


### PR DESCRIPTION
## What

Implements the independent **Phase 4b AIRR/scverse contract** — the AIRR→Benisse boundary — without creating a public package/API and without touching the Phase 4a harness. Built and tested against synthetic objects and the local AP4 fixture while Phase 4a is in progress.

## Contents

- **`airr_adapter.py`** (internal, pre-API):
  - Deterministic heavy-chain selection: `IGH` + productive + non-empty `junction_aa`, ranked by abundance → `junction_aa` → `sequence_id` (a total order, so input-chain-order-independent).
  - Reversible `-`↔`.` barcode join normalisation with an injectivity/round-trip guard (never mutates the object's IDs).
  - AIRR→encoder field mapping (`contigs`←`sequence_id`, `cdr3`←`junction_aa`, keeping the conserved C..W/F junction residues).
  - Embedding writes into the AIRR modality `obsm` that preserve `airr`/`chain_indices`.
  - `BenisseNetworkResult` clonotype-network schema stored in `uns` with an explicit node index (not cell-aligned `obsp`, since nodes are receptors, not cells).
- **`tests/test_airr_adapter.py`** — 14 synthetic-object tests (always run).
- **`tests/test_airr_adapter_ap4.py`** — 6 parity tests on the local AP4 fixture (skip when the gitignored object is absent).
- **`derive_ap4_encoder_input.py`** — reproducible encoder-input derivation to gitignored `data/external/` (licence-safe) with a provenance sidecar.
- **`PHASE4B_NOTES.md`** — unresolved interface assumptions for post-4a integration.

## Verification

`conda run -n benisse-scirpy022 python -m pytest -q` → **24 passed, 1 skipped** (the slow pipeline test).

Key parity results: our independent heavy-chain ranking matches scirpy's `chain_indices` primary VDJ pointer on **all 203** AP4 cells; derived counts match `data/manifest.yaml` `airr_summary` exactly (216 productive IGH / 214 unique junctions; loci IGH/IGK/IGL = 233/138/121).

## Scope guard

Does **not** modify `AchillesEncoder.py`, `pytest.ini`, `data/manifest.yaml`, `environment-scirpy022.yml`, or existing Phase 4a tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
