### PR TITLE
Strengthen scientific parity invariants

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1,4 +1,10 @@
 library(data.table)
+
+graphChangeMSE=function(current_graph,previous_graph)
+{
+  sum((current_graph-previous_graph)^2)/nrow(current_graph)^2
+}
+
 Benisse=function(hyper_para,cdr3exp,t,meta_dedup,exp_data,max_iter,
                  save_path,mode,stop_cutoff,simu_initiation=NA,sample=NA,rm_cutoff=NA)
 {
@@ -38,7 +44,7 @@ Benisse=function(hyper_para,cdr3exp,t,meta_dedup,exp_data,max_iter,
       # Mean squared per-entry graph change over each of the last 10 updates.
       # Parenthesize the elementwise delta before squaring so positive and
       # negative edge changes cannot cancel before the norm is calculated.
-      res_vec=sapply(1:10,function(r) sum((res[[r]]-res_back[[r]])^2)/nrow(sparse_graph)^2)
+      res_vec=sapply(1:10,function(r) graphChangeMSE(res[[r]],res_back[[r]]))
       if(mean(res_vec)<stop_cutoff&sd(res_vec)<1e-4){
         print(mean(res_vec))
         print(paste('Convergence: iteration',i))

--- a/UPDATE_PLAN.md
+++ b/UPDATE_PLAN.md
@@ -1,6 +1,6 @@
 # Benisse Update Plan
 
-Status: LIVING PLAN — Phase 4a complete; Phase 4b AnnData/AIRR I/O is next
+Status: LIVING PLAN — Phase 4a audit follow-up active; Phase 4b contract merged
 Date: 2026-07-18
 
 Benisse is a two-stage BCR analysis tool: a Python/torch encoder embeds BCR CDR3H
@@ -41,8 +41,8 @@ verified), **ACTIVE** (current branch), **PENDING** (ready but not started), **D
 | AIRR processed-data license | **BLOCKED** | Confirm redistribution terms before publishing either downloaded object; objects remain gitignored. |
 | Large-file/history cleanup | **PENDING** | Coordinate the remaining asset migration and one repository-wide history rewrite later; document Zenodo/DOI implications first. |
 | In-house cohort data | **DONE in active tree; history pending** | Archived on the existing Figshare record and removed from the repository tree at the maintainer's direction; remove its old blob during the coordinated history rewrite. |
-| Phase 4a parity harness/internal modularization | **DONE** | Pytest: 4 fast checks pass; the marked full Python+R oracle passes with exact encoder/text bytes, semantic RData equality, 3,382 exact sparse entries, and pixel-identical plots. |
-| Phase 4b AnnData/AIRR I/O | **PENDING — NEXT; groundwork ready** | Define Benisse↔AIRR field mapping and use the AP4 fixture for tests. |
+| Phase 4a parity harness/internal modularization | **DONE; audit strengthened** | Combined post-Phase-4b pytest: 29 passed, 1 slow skipped. Direct convergence cancellation coverage, true multi-file/order metamorphic cases, encoder schema checks, hash-ledger completeness, and R scientific invariants supplement the full oracle. |
+| Phase 4b AnnData/AIRR I/O | **DONE; open integration assumptions documented** | Claude Code's `61c91fb` was merged by PR #17 into `develop/v2-modernization` at `2e7a940`; synthetic and optional AP4 adapter tests, field mapping, embedding/result schemas, and derivation tooling are included. Track Awkward's experimental support and MuData 0.4's upcoming `.update()` behavior before lifting versions. |
 | Phase 4c Python→R bridge | **PENDING** | Follows 4b and provides an end-to-end Python-facing scientific harness. |
 | Phase 4d R-core port | **PENDING** | Compare against the corrected R oracle with exact edge-set checks. |
 | Phase 2 Python plots | **DEFERRED** | Implement after 4d so plots use the lasting Python result object. |
@@ -51,6 +51,29 @@ verified), **ACTIVE** (current branch), **PENDING** (ready but not started), **D
 
 ### Work log
 
+- **2026-07-18 — independent Phase 4a test audit follow-up
+  (`test/scientific-parity-harness`).** A fresh-context agent found that the single full oracle
+  was strong but could miss regression of the corrected convergence formula and lacked
+  metamorphic/invariant checks. Extracted `graphChangeMSE` for a direct opposing-change
+  cancellation test; replaced the duplicate-only multi-file assumption with disjoint file and
+  order-permutation cases; asserted the callable encoder's 20-dimensional finite schema;
+  asserted hash-ledger completeness; and added fast R checks for symmetry, bounds, positive
+  definiteness, graph support, and latent-distance properties. Added a 30-minute subprocess
+  timeout to the full harness. The audit also established that `sparse_graph.txt` is weighted
+  `A`, while binary adjacency lives in `results$sparse_graph`; downstream interfaces must keep
+  that distinction explicit. Fast result: 9 passed, 1 slow skipped. Full oracle after the R
+  helper extraction: 1 passed in 10m17s, converging at iteration 33 with exact stable outputs,
+  semantic RData equality, 3,382 binary sparse-matrix entries, and pixel-identical plots. After
+  rebasing onto merged Phase 4b, the combined fast suite passed 29 tests with 1 slow skip. Its
+  19 upstream warnings are retained as compatibility signals: Awkward-in-AnnData support is
+  experimental and MuData 0.4 will change `.update()` pull behavior.
+- **2026-07-18 — Claude Code Phase 4b merged.** Commit `61c91fb` (`Add Phase 4b AIRR/scverse
+  contract adapter and tests`) was merged by PR #17 into `develop/v2-modernization` at
+  `2e7a940`. It contains `airr_adapter.py`, `derive_ap4_encoder_input.py`,
+  `PHASE4B_NOTES.md`, and two adapter test modules. The contract is implemented and tested;
+  its documented open assumptions (notably R node ordering, result wiring, input surface,
+  count precedence, and final module placement) carry into Phases 4c/4e. Phase 4a audit
+  follow-up deliberately avoids modifying those files.
 - **2026-07-18 — Phase 4a scientific parity harness
   (`test/scientific-parity-harness`).** Extracted a callable `encode_bcr` boundary while
   preserving the legacy CLI. Added pytest coverage for CLI boolean parsing, exact callable

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,9 +9,10 @@ Run the fast pytest checks in the `benisse-scirpy022` environment:
 conda run -n benisse-scirpy022 python -m pytest -v
 ```
 
-The fast suite checks the callable encoder, duplicate multi-file input, and every committed
-reference hash. It runs entirely on CPU; the full pipeline test is skipped unless explicitly
-enabled.
+The fast suite checks the callable encoder contract, duplicate and disjoint multi-file input,
+input-order invariance, every committed reference hash, the corrected convergence norm, and
+scientific invariants of the R oracle. It runs entirely on CPU; the full pipeline test is
+skipped unless explicitly enabled.
 
 Run the complete Python + R oracle check explicitly:
 
@@ -23,3 +24,8 @@ The complete check takes several minutes. Stable CSV/text outputs are compared b
 `Benisse_results.RData` is compared semantically with exact sparse-edge agreement, and PDF
 plots are rasterized with `pdftoppm` before byte comparison so timestamps do not cause false
 failures.
+
+Despite its filename, `example/sparse_graph.txt` stores the weighted matrix `A`. The binary
+adjacency used for exact edge-set parity is `results$sparse_graph` inside
+`example/Benisse_results.RData`. Tests preserve and assert this distinction for downstream
+AnnData and Python-port interfaces.

--- a/tests/test_encoder_parity.py
+++ b/tests/test_encoder_parity.py
@@ -3,6 +3,8 @@ import hashlib
 import shutil
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from AchillesEncoder import encode_bcr, strtobool
@@ -21,6 +23,15 @@ def sha256(path):
     return digest.hexdigest()
 
 
+def scientific_encoding(path):
+    """Read the CDR3-to-embedding mapping without the incidental CSV row index."""
+    return (
+        pd.read_csv(path, index_col=0)
+        .sort_values("index", kind="mergesort")
+        .reset_index(drop=True)
+    )
+
+
 def test_boolean_parser():
     assert strtobool("TRUE") is True
     assert strtobool("false") is False
@@ -34,13 +45,17 @@ def test_callable_encoder_matches_reference_bytes(tmp_path):
 
     reference_rows = len(REFERENCE_ENCODING.read_text().splitlines()) - 1
     assert len(encoded) == reference_rows
+    assert list(encoded.columns) == list(range(20)) + ["index"]
+    assert encoded["index"].is_unique
+    assert encoded["index"].notna().all()
+    assert np.isfinite(encoded[list(range(20))].to_numpy()).all()
     assert output.read_bytes() == REFERENCE_ENCODING.read_bytes()
     assert sha256(output) == (
         "400eb1b07fe436779d138c494ca28bdb7c0cb630ef1e05cb5047c62fde56605d"
     )
 
 
-def test_multifile_encoder_matches_single_file_reference(tmp_path):
+def test_duplicate_multifile_encoder_matches_single_file_reference(tmp_path):
     input_dir = tmp_path / "inputs"
     input_dir.mkdir()
     shutil.copyfile(EXAMPLE_INPUT, input_dir / "a.csv")
@@ -50,3 +65,41 @@ def test_multifile_encoder_matches_single_file_reference(tmp_path):
     encode_bcr(input_dir, output, cuda=False)
 
     assert output.read_bytes() == REFERENCE_ENCODING.read_bytes()
+
+
+@pytest.mark.parametrize("reverse_files", [False, True])
+def test_disjoint_multifile_encoder_concatenates_all_rows(tmp_path, reverse_files):
+    frame = pd.read_csv(EXAMPLE_INPUT)
+    split_at = len(frame) // 2
+    first, second = frame.iloc[:split_at], frame.iloc[split_at:]
+    if reverse_files:
+        first, second = second, first
+
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    first.to_csv(input_dir / "a.csv", index=False)
+    second.to_csv(input_dir / "b.csv", index=False)
+    output = tmp_path / "encoded.csv"
+
+    encode_bcr(input_dir, output, cuda=False)
+
+    pd.testing.assert_frame_equal(
+        scientific_encoding(output),
+        scientific_encoding(REFERENCE_ENCODING),
+        check_exact=True,
+    )
+
+
+def test_encoder_is_invariant_to_input_row_order(tmp_path):
+    frame = pd.read_csv(EXAMPLE_INPUT).iloc[::-1]
+    reversed_input = tmp_path / "reversed.csv"
+    frame.to_csv(reversed_input, index=False)
+    output = tmp_path / "encoded.csv"
+
+    encode_bcr(reversed_input, output, cuda=False)
+
+    pd.testing.assert_frame_equal(
+        scientific_encoding(output),
+        scientific_encoding(REFERENCE_ENCODING),
+        check_exact=True,
+    )

--- a/tests/test_r_scientific_invariants.py
+++ b/tests/test_r_scientific_invariants.py
@@ -1,0 +1,74 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RSCRIPT = shutil.which("Rscript")
+
+
+def run_r(expression):
+    try:
+        subprocess.run(
+            [RSCRIPT, "-e", expression],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as error:
+        pytest.fail(f"R component check failed:\n{error.stdout}\n{error.stderr}")
+
+
+@pytest.mark.skipif(RSCRIPT is None, reason="Rscript is required for R component checks")
+def test_convergence_norm_does_not_cancel_opposing_changes():
+    run_r(
+        """
+source('R/util.R')
+previous <- matrix(0, nrow=2, ncol=2)
+current <- matrix(c(0, 1, -1, 0), nrow=2, byrow=TRUE)
+legacy <- sum(current-previous)^2/nrow(current)^2
+corrected <- graphChangeMSE(current, previous)
+stopifnot(legacy == 0)
+stopifnot(isTRUE(all.equal(corrected, 0.5)))
+"""
+    )
+
+
+@pytest.mark.skipif(RSCRIPT is None, reason="Rscript is required for R component checks")
+def test_committed_oracle_satisfies_scientific_invariants():
+    run_r(
+        """
+load('example/Benisse_results.RData')
+A <- results$A
+Q <- results$Q
+SI <- results$SI
+latent <- as.matrix(read.table('example/latent_dist.txt'))
+sparse <- as.matrix(read.table('example/sparse_graph.txt'))
+tolerance <- 1e-10
+
+stopifnot(all(is.finite(A)))
+stopifnot(max(abs(A-t(A))) < tolerance)
+stopifnot(max(abs(diag(A))) < tolerance)
+stopifnot(min(A) >= -tolerance, max(A) <= 1+tolerance)
+stopifnot(all(abs(A[SI == 0]) < tolerance))
+
+stopifnot(all(is.finite(Q)))
+stopifnot(max(abs(Q-t(Q))) < tolerance)
+stopifnot(min(eigen(Q, symmetric=TRUE, only.values=TRUE)$values) > 0)
+
+stopifnot(all(is.finite(latent)), min(latent) >= -tolerance)
+stopifnot(max(abs(latent-t(latent))) < tolerance)
+stopifnot(max(abs(diag(latent))) < tolerance)
+
+stopifnot(max(abs(sparse-t(sparse))) < tolerance)
+stopifnot(max(abs(diag(sparse))) < tolerance)
+stopifnot(min(sparse) >= -tolerance, max(sparse) <= 1+tolerance)
+stopifnot(all(sparse[SI == 0] == 0))
+stopifnot(isTRUE(all.equal(sparse, A, check.attributes=FALSE)))
+stopifnot(all((sparse > 0) == (results$sparse_graph == 1)))
+"""
+    )

--- a/tests/test_reference_hashes.py
+++ b/tests/test_reference_hashes.py
@@ -4,11 +4,24 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HASH_LEDGER = REPO_ROOT / "example" / "reference-output-hashes.sha256"
+EXPECTED_REFERENCES = {
+    "example/encoded_10x_NSCLC.csv",
+    "example/Benisse_results.RData",
+    "example/cleaned_exp.txt",
+    "example/clonality_label.txt",
+    "example/clone_annotation.csv",
+    "example/connectionplot.pdf",
+    "example/in_cross_dist_check.pdf",
+    "example/latent_dist.txt",
+    "example/sparse_graph.txt",
+}
 
 
 def test_committed_reference_hashes():
-    for line in HASH_LEDGER.read_text().splitlines():
-        expected, relative_path = line.split(maxsplit=1)
+    entries = [line.split(maxsplit=1) for line in HASH_LEDGER.read_text().splitlines()]
+    assert {relative_path for _, relative_path in entries} == EXPECTED_REFERENCES
+
+    for expected, relative_path in entries:
         path = REPO_ROOT / relative_path
         assert path.is_file(), relative_path
         assert hashlib.sha256(path.read_bytes()).hexdigest() == expected, relative_path

--- a/tests/verify_reference_pipeline.py
+++ b/tests/verify_reference_pipeline.py
@@ -21,9 +21,14 @@ STABLE_R_OUTPUTS = (
 PDF_OUTPUTS = ("connectionplot.pdf", "in_cross_dist_check.pdf")
 
 
-def run(command):
+def run(command, timeout=1800):
     print("+", " ".join(map(str, command)), flush=True)
-    subprocess.run([str(part) for part in command], cwd=REPO_ROOT, check=True)
+    subprocess.run(
+        [str(part) for part in command],
+        cwd=REPO_ROOT,
+        check=True,
+        timeout=timeout,
+    )
 
 
 def require_executable(name):


### PR DESCRIPTION
## Summary
- add a direct regression test for convergence-change cancellation
- cover true disjoint multi-file concatenation and input-order invariance
- assert the callable encoder schema, finiteness, and hash-ledger completeness
- add fast R scientific invariants for A, Q, SI, latent distances, and weighted-vs-binary graph semantics
- add a timeout to the full oracle harness and record the audit plus merged Phase 4b status in the living plan

## Verification
- combined fast suite after PR #17: 29 passed, 1 slow skipped
- full Python and R oracle: 1 passed in 10m17s
- convergence: iteration 33
- exact stable output parity, semantic RData equality, 3,382 binary sparse-matrix entries, and pixel-identical plots
- git diff check, Python compilation, and R parse checks pass

## Important contract clarification
The file example/sparse_graph.txt stores weighted A. The exact binary adjacency is results inside the RData. The new tests preserve this distinction for downstream bridge and Python-port work.