### PR TITLE
Phase 4c: Python->R bridge around the unmodified Benisse.R

### DIFF
--- a/PHASE4C_NOTES.md
+++ b/PHASE4C_NOTES.md
@@ -1,0 +1,95 @@
+# Phase 4c Python→R bridge — status and open interface assumptions
+
+Status: interim Python→R bridge around the **unmodified** `Benisse.R`,
+implemented and tested. Builds on the hardened Phase 4b schema (PR #19). No
+public/scverse package or CLI yet (that is 4e); the Python core port is 4d.
+
+## What was delivered
+
+- `benisse_bridge.py` (internal, pre-API):
+  - `BenisseRParams` — the 7 positional R params (CLI args 5–11); defaults
+    reproduce the committed `example/` run. `lambda2` scales with dataset size
+    (example uses 1610 ≈ BCR-cell count), so set it per dataset.
+  - `build_benisse_command` / `run_benisse_r` — assemble and run
+    `Rscript Benisse.R …` as a subprocess; clear errors on missing inputs and on
+    non-zero R exit (captured stderr). subprocess, not rpy2 (fragile on this
+    stack); the R call is hidden behind one Python function.
+  - `encode_bcr_csv` — encoder via `from AchillesEncoder import encode_bcr`
+    (import-and-call, the scverse-idiomatic way, not the CLI).
+  - `read_benisse_network` (+ `read_sparse_graph`, `read_clone_annotation`,
+    `clone_keys`) — parse `sparse_graph.txt` (`results$A`) and
+    `clone_annotation.csv` into a validated `BenisseNetworkResult`: node_ids are
+    the **clone keys** `v_gene_cdr3_j_gene` from the R side (honouring the 4b
+    node-identity correction), edges are the upper triangle of the symmetric `A`
+    (undirected convention). Asserts A square/symmetric/dimension-aligned.
+  - `run_pipeline` — end-to-end from standard Benisse CSVs: encode → run R →
+    parse.
+- `tests/test_benisse_bridge.py` — 9 fast tests (params/command assembly,
+  subprocess error handling, synthetic parsing, and parsing the **committed
+  `example/` reference outputs** = real R-oracle validation without running R),
+  plus 1 slow end-to-end (encode + R core, edge-set match vs reference; runs
+  under `BENISSE_RUN_SLOW_TESTS=1` with `Rscript` available).
+
+## R contract learned (grounding the bridge)
+
+- CLI args: `exp.csv contigs.csv encoded.csv out_dir lambda2 gamma max_iter
+  lambda1 rho m stop_cutoff`.
+- `Benisse.R` uses **IGH-only** refined contigs for the graph; clone key is
+  `paste(v_gene, cdr3, j_gene, sep='_')`; it keeps contigs whose `cdr3` is in the
+  encoded matrix's `index`.
+- `sparse_graph.txt` = dense space-separated `A` (no header/rownames), symmetric,
+  zero diagonal, weights in (0,1]. `clone_annotation.csv` = per-node metadata
+  (`v_gene,j_gene,cdr3,clsize,graph_label`, barcode rowname) in the **same order**
+  as `A` (initiation.R reindexes distances back to `meta_dedup$clone` order).
+- Reference `example/` run: 1494 nodes, 1691 undirected edges, weights [0.5, 1.0].
+
+## Deferred: the MuData→R-inputs prep (the fragile part)
+
+`run_pipeline` takes the three standard Benisse CSVs. Building `exp.csv` and
+`contigs.csv` **from a MuData/AIRR object** was deliberately deferred, because it
+is where a wrong guess causes silent scientific error and it overlaps with
+public-API decisions. Specifics discovered, for whoever implements it:
+
+- `R/prepare.R` does `gsub('-','.', barcode)` and `intersect`s with `exp` column
+  names, relying on R `read.csv`'s `make.names` to dot the `exp` header too. So a
+  generated `exp.csv` can keep canonical hyphenated barcodes (R dots both sides);
+  do not pre-dot only one side. `assert_reversible_barcodes` still applies.
+- `exp.csv` = genes × cells, gene ids in column 1 (unnamed header → R reads it as
+  `X`). Source: `mdata.mod["gex"]` (decide raw layer vs `X`).
+- `contigs.csv` = 10x `all_contig` format. `prepare.R` filters
+  `is_cell=='True' & high_confidence=='True' & full_length=='True' &
+  productive=='True' & chain=='IGH'` (string `'True'`), then per barcode keeps the
+  max-`umis` row. AIRR objects do **not** carry `is_cell/high_confidence/
+  full_length` as such; mapping scirpy QC → these flags is an explicit decision,
+  not a mechanical rename. Emit all productive IGH chains and let R dedup, or
+  reproduce R's max-umi pick in Python.
+- Once implemented, wire `airr_adapter.attach_network_result(mdata, result)` so
+  the MuData-native call returns the network in `uns`.
+
+## Coordination with Phase 4d (Codex, in parallel)
+
+- `read_benisse_network` is **shared infrastructure**: the 4d Python port should
+  reuse it to parse the R oracle and compare against its own output. The
+  strengthened parity gate (discrete edge-set / Jaccard on `sparse_graph`, per
+  UPDATE_PLAN.md 4d) can be expressed directly as set equality on the
+  `BenisseNetworkResult` edge triples, exactly as the slow test does here.
+- The public function boundary (`run_pipeline` / `run_benisse_r` →
+  `BenisseNetworkResult`) is the seam 4d slots into: 4d swaps the R subprocess
+  for ported Python behind the same signature and schema.
+- 4d must target the **corrected** convergence oracle (`util.R:38`,
+  `sum(delta^2)/n^2`) — the `example/` reference outputs used here reflect the
+  current committed `Benisse.R`; re-baseline if the convergence fix lands.
+
+## Open interface assumptions
+
+1. **Encoder seam.** `encode_bcr_csv` imports `encode_bcr(input, output,
+   cuda=…)`. Phase 4a (Codex) is refactoring the encoder; if that signature
+   changes, this one call site needs updating (4a tests pin the behaviour).
+2. **Params identity.** `lambda2` is dataset-scale-dependent; there is no safe
+   universal default. Consider deriving a default from node count at the
+   MuData-native layer.
+3. **Symmetry tolerance.** `read_benisse_network` asserts `A` symmetric within
+   `atol=1e-8`. If a future core emits an asymmetric/directed graph, pass
+   `directed=True` semantics through instead of upper-triangularising.
+4. **Output plots.** PDF outputs are returned as paths but not parsed; plot
+   parity is out of scope until the Phase 2 Python plotting rebuild.

--- a/benisse_bridge.py
+++ b/benisse_bridge.py
@@ -1,0 +1,279 @@
+"""Phase 4c Python->R bridge for the Benisse core (INTERNAL, PRE-API).
+
+Exposes the Benisse R core from Python as an import-and-call interface, without
+betting correctness on an unproven port: it runs the **unmodified** ``Benisse.R``
+as a subprocess and parses its outputs into the Phase 4b
+:class:`airr_adapter.BenisseNetworkResult` schema. This is the interim
+scientific interface described in ``UPDATE_PLAN.md`` Phase 4c; the polished
+public/scverse API and the Python core port (4d/4e) come later.
+
+Design (see the 4c discussion and PHASE4C_NOTES.md):
+
+* subprocess, not rpy2 -- rpy2 on this Intel-mac + R 4.3 stack is fragile and
+  buys nothing the single-function-call wrapper does not already give. The R
+  invocation is an implementation detail hidden behind :func:`run_benisse_r`.
+* The encoder is called by import (``from AchillesEncoder import encode_bcr``),
+  the scverse-idiomatic way, not via its CLI.
+* Graph nodes are Benisse's deduplicated clone keys (``v_gene_cdr3_j_gene``),
+  taken from the R side (``clone_annotation.csv``), NOT per-cell contigs -- see
+  the node-identity correction in ``airr_adapter`` / PHASE4B_NOTES.md #6.
+
+:func:`read_benisse_network` is deliberately standalone so the Phase 4d Python
+port can validate against the same parsed-oracle representation.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from airr_adapter import BenisseNetworkResult, validate_network_result, benisse_provenance
+
+REPO_ROOT = Path(__file__).resolve().parent
+DEFAULT_BENISSE_R = REPO_ROOT / "Benisse.R"
+
+#: Files ``Benisse.R`` writes into its output directory.
+OUTPUT_FILES = {
+    "clone_annotation": "clone_annotation.csv",
+    "cleaned_exp": "cleaned_exp.txt",
+    "clonality_label": "clonality_label.txt",
+    "sparse_graph": "sparse_graph.txt",
+    "latent_dist": "latent_dist.txt",
+    "results_rdata": "Benisse_results.RData",
+    "connection_plot": "connectionplot.pdf",
+    "cross_dist_plot": "in_cross_dist_check.pdf",
+}
+
+
+@dataclass
+class BenisseRParams:
+    """Positional parameters for ``Benisse.R`` (CLI args 5-11).
+
+    Defaults reproduce the committed ``example/`` run. ``lambda2`` scales with the
+    dataset (the example uses 1610 ~= the BCR-cell count), so set it per dataset
+    rather than trusting the default.
+    """
+
+    lambda2: float = 1610
+    gamma: float = 1
+    max_iter: int = 100
+    lambda1: float = 1
+    rho: float = 1
+    m: int = 10
+    stop_cutoff: float = 1e-10
+
+    def as_cli_args(self) -> list[str]:
+        # Order matches Benisse.R args[5..11].
+        return [
+            _fmt(self.lambda2), _fmt(self.gamma), _fmt(self.max_iter),
+            _fmt(self.lambda1), _fmt(self.rho), _fmt(self.m), _fmt(self.stop_cutoff),
+        ]
+
+
+def _fmt(value: Any) -> str:
+    """Format a numeric CLI arg without spurious trailing ``.0`` for integers."""
+    if isinstance(value, bool):
+        raise TypeError("boolean is not a valid Benisse.R numeric parameter")
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and value.is_integer() and abs(value) < 1e15:
+        return str(int(value))
+    return repr(value) if isinstance(value, float) else str(value)
+
+
+# --- Running the unmodified Benisse.R ------------------------------------
+
+
+def build_benisse_command(
+    exp_csv, contigs_csv, encoded_csv, out_dir, params: BenisseRParams,
+    *, benisse_r=DEFAULT_BENISSE_R, rscript: str = "Rscript",
+) -> list[str]:
+    """Assemble the ``Rscript Benisse.R ...`` argv (no side effects)."""
+    return [
+        rscript, str(benisse_r),
+        str(exp_csv), str(contigs_csv), str(encoded_csv), str(out_dir),
+        *params.as_cli_args(),
+    ]
+
+
+def run_benisse_r(
+    exp_csv, contigs_csv, encoded_csv, out_dir, params: BenisseRParams | None = None,
+    *, benisse_r=DEFAULT_BENISSE_R, rscript: str = "Rscript",
+    timeout: float | None = None, check: bool = True,
+) -> dict[str, Path]:
+    """Run the unmodified ``Benisse.R`` on the three input CSVs.
+
+    Returns a mapping of the output file paths under *out_dir* (see
+    :data:`OUTPUT_FILES`). Raises ``FileNotFoundError`` for a missing input/script
+    and ``RuntimeError`` (with captured stderr) on a non-zero R exit.
+    """
+    params = params or BenisseRParams()
+    exp_csv, contigs_csv, encoded_csv = map(Path, (exp_csv, contigs_csv, encoded_csv))
+    benisse_r = Path(benisse_r)
+    for path in (exp_csv, contigs_csv, encoded_csv, benisse_r):
+        if not path.exists():
+            raise FileNotFoundError(f"required input does not exist: {path}")
+    if shutil.which(rscript) is None:
+        raise FileNotFoundError(
+            f"Rscript executable not found: {rscript!r}. Install R or pass rscript=."
+        )
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = build_benisse_command(
+        exp_csv, contigs_csv, encoded_csv, out_dir, params,
+        benisse_r=benisse_r, rscript=rscript,
+    )
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if check and proc.returncode != 0:
+        raise RuntimeError(
+            f"Benisse.R failed (exit {proc.returncode}).\n"
+            f"command: {' '.join(cmd)}\n"
+            f"--- stderr (tail) ---\n{_tail(proc.stderr)}"
+        )
+    return {name: out_dir / fname for name, fname in OUTPUT_FILES.items()}
+
+
+def _tail(text: str, lines: int = 40) -> str:
+    return "\n".join((text or "").splitlines()[-lines:])
+
+
+# --- Encoder (imported, not CLI) -----------------------------------------
+
+
+def encode_bcr_csv(encoder_input_csv, encoded_csv, *, cuda: bool = False) -> Path:
+    """Run the Benisse encoder on an encoder-input CSV via ``encode_bcr`` import.
+
+    *encoder_input_csv* has the ``contigs``/``cdr3`` columns produced by
+    :func:`airr_adapter.build_encoder_input`. Returns the encoded CSV path.
+    """
+    from AchillesEncoder import encode_bcr
+
+    encoded_csv = Path(encoded_csv)
+    encode_bcr(str(encoder_input_csv), str(encoded_csv), cuda=cuda)
+    return encoded_csv
+
+
+# --- Parsing R output into the 4b schema ---------------------------------
+
+
+def read_clone_annotation(out_dir_or_file) -> pd.DataFrame:
+    """Read ``clone_annotation.csv`` (node metadata, one row per graph node)."""
+    path = _resolve(out_dir_or_file, "clone_annotation")
+    ann = pd.read_csv(path, index_col=0)
+    required = {"v_gene", "j_gene", "cdr3"}
+    missing = required - set(ann.columns)
+    if missing:
+        raise ValueError(f"clone_annotation.csv missing columns {sorted(missing)}.")
+    return ann
+
+
+def clone_keys(annotation: pd.DataFrame) -> list[str]:
+    """Benisse clone keys ``v_gene_cdr3_j_gene`` in graph-node order."""
+    return [
+        f"{v}_{c}_{j}"
+        for v, c, j in zip(annotation["v_gene"], annotation["cdr3"], annotation["j_gene"])
+    ]
+
+
+def read_sparse_graph(out_dir_or_file) -> np.ndarray:
+    """Read ``sparse_graph.txt`` (dense, space-separated ``results$A``)."""
+    path = _resolve(out_dir_or_file, "sparse_graph")
+    # np.loadtxt returns a 0-d scalar for a 1x1 matrix and a 1-d row for a single
+    # line; atleast_2d normalises the 1-node case while a genuine 1xN row still
+    # fails the square check below.
+    A = np.atleast_2d(np.loadtxt(path))
+    if A.ndim != 2 or A.shape[0] != A.shape[1]:
+        raise ValueError(f"sparse_graph.txt is not square: shape {A.shape}.")
+    return A
+
+
+def read_benisse_network(
+    out_dir, *, params: BenisseRParams | None = None,
+    provenance: dict[str, Any] | None = None, symmetry_atol: float = 1e-8,
+) -> BenisseNetworkResult:
+    """Parse ``Benisse.R`` outputs into a validated ``BenisseNetworkResult``.
+
+    Nodes are the deduplicated clone keys from ``clone_annotation.csv``; edges are
+    the upper triangle of the symmetric adjacency ``A`` (``sparse_graph.txt``),
+    matching the schema's undirected convention. Asserts ``A`` is square,
+    symmetric, and dimension-aligned to the annotation.
+    """
+    A = read_sparse_graph(out_dir)
+    annotation = read_clone_annotation(out_dir)
+    if len(annotation) != A.shape[0]:
+        raise ValueError(
+            f"clone_annotation rows ({len(annotation)}) != adjacency dim ({A.shape[0]})."
+        )
+    if not np.isfinite(A).all():
+        raise ValueError("adjacency A contains non-finite (NaN/inf) values.")
+    if not np.allclose(A, A.T, atol=symmetry_atol):
+        raise ValueError("adjacency A is not symmetric; expected an undirected graph.")
+    if not np.allclose(np.diag(A), 0.0, atol=symmetry_atol):
+        raise ValueError("adjacency A has a nonzero diagonal (self-loops); expected zero.")
+
+    nodes = clone_keys(annotation)
+    upper = np.triu(A, k=1)  # k=1 drops the (zero) diagonal / self-loops
+    row, col = np.nonzero(upper)
+    weight = upper[row, col]
+
+    prov = benisse_provenance(
+        source_dir=str(Path(out_dir)),
+        n_nodes=int(A.shape[0]),
+        n_edges=int(row.size),
+        weight_min=float(weight.min()) if weight.size else None,
+        weight_max=float(weight.max()) if weight.size else None,
+        **(provenance or {}),
+    )
+    result = BenisseNetworkResult(
+        node_ids=nodes,
+        row=row.astype("int64"),
+        col=col.astype("int64"),
+        weight=weight.astype("float64"),
+        params=asdict(params) if params else {},
+        provenance=prov,
+        directed=False,
+    )
+    validate_network_result(result)
+    return result
+
+
+# --- End-to-end (from standard Benisse CSV inputs) -----------------------
+
+
+def run_pipeline(
+    encoder_input_csv, exp_csv, contigs_csv, out_dir,
+    params: BenisseRParams | None = None, *, cuda: bool = False,
+    benisse_r=DEFAULT_BENISSE_R, rscript: str = "Rscript",
+    timeout: float | None = None,
+) -> BenisseNetworkResult:
+    """Encode CDR3H, run the R core, and parse the clonotype network.
+
+    End-to-end Python UX around the unmodified core: encodes *encoder_input_csv*
+    (``contigs``/``cdr3``) with the Benisse encoder, runs ``Benisse.R`` against the
+    expression and contigs CSVs, and returns the parsed
+    :class:`~airr_adapter.BenisseNetworkResult`.
+    """
+    params = params or BenisseRParams()
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    encoded_csv = encode_bcr_csv(encoder_input_csv, out_dir / "encoded.csv", cuda=cuda)
+    run_benisse_r(
+        exp_csv, contigs_csv, encoded_csv, out_dir, params,
+        benisse_r=benisse_r, rscript=rscript, timeout=timeout,
+    )
+    return read_benisse_network(out_dir, params=params)
+
+
+def _resolve(out_dir_or_file, key: str) -> Path:
+    """Accept either a directory (join the known filename) or a direct file path."""
+    path = Path(out_dir_or_file)
+    if path.is_dir():
+        return path / OUTPUT_FILES[key]
+    return path

--- a/tests/test_benisse_bridge.py
+++ b/tests/test_benisse_bridge.py
@@ -1,0 +1,218 @@
+"""Phase 4c Python->R bridge tests.
+
+Fast tests (always run) cover CLI-arg assembly, subprocess error handling, and
+parsing R outputs into the 4b schema -- including parsing the committed
+``example/`` reference outputs, which validates the parser against *real* R
+oracle output without running R. The full encode+R end-to-end is a slow test,
+skipped unless ``BENISSE_RUN_SLOW_TESTS=1`` and ``Rscript`` is available.
+"""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import airr_adapter as aa  # noqa: E402
+import benisse_bridge as bb  # noqa: E402
+
+EXAMPLE = REPO_ROOT / "example"
+
+
+# --- parameters and command assembly --------------------------------------
+
+
+def test_params_default_cli_args_order_and_format():
+    args = bb.BenisseRParams().as_cli_args()
+    # lambda2, gamma, max_iter, lambda1, rho, m, stop_cutoff (example defaults)
+    assert args == ["1610", "1", "100", "1", "1", "10", "1e-10"]
+
+
+def test_fmt_keeps_integers_clean_and_rejects_bool():
+    assert bb._fmt(100) == "100"
+    assert bb._fmt(1.0) == "1"        # no spurious ".0"
+    assert bb._fmt(1e-10) == "1e-10"
+    with pytest.raises(TypeError):
+        bb._fmt(True)
+
+
+def test_build_command_positions_all_args():
+    cmd = bb.build_benisse_command(
+        "e.csv", "c.csv", "enc.csv", "/out", bb.BenisseRParams(lambda2=42),
+        benisse_r="/repo/Benisse.R", rscript="Rscript",
+    )
+    assert cmd[:6] == ["Rscript", "/repo/Benisse.R", "e.csv", "c.csv", "enc.csv", "/out"]
+    assert cmd[6] == "42"  # lambda2
+    assert cmd[-1] == "1e-10"  # stop_cutoff
+
+
+# --- subprocess error handling --------------------------------------------
+
+
+def test_run_benisse_r_missing_input_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        bb.run_benisse_r(
+            tmp_path / "nope_exp.csv", tmp_path / "nope_c.csv",
+            tmp_path / "nope_enc.csv", tmp_path / "out",
+        )
+
+
+def test_run_benisse_r_propagates_nonzero_exit(tmp_path):
+    # Real inputs so the existence checks pass, but a command that always fails.
+    for name in ("exp.csv", "contigs.csv", "encoded.csv", "Benisse.R"):
+        (tmp_path / name).write_text("x")
+    with pytest.raises(RuntimeError, match="exit"):
+        bb.run_benisse_r(
+            tmp_path / "exp.csv", tmp_path / "contigs.csv", tmp_path / "encoded.csv",
+            tmp_path / "out", benisse_r=tmp_path / "Benisse.R", rscript="/usr/bin/false",
+        )
+
+
+# --- parsing R output into the 4b schema ----------------------------------
+
+
+def _write_fake_outputs(out_dir, A, clone_rows):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    np.savetxt(out_dir / bb.OUTPUT_FILES["sparse_graph"], A)
+    header = '"","v_gene","j_gene","cdr3","clsize","graph_label"\n'
+    lines = [header]
+    for i, (bc, v, j, c) in enumerate(clone_rows):
+        lines.append(f'"{bc}","{v}","{j}","{c}",1,"single {i}"\n')
+    (out_dir / bb.OUTPUT_FILES["clone_annotation"]).write_text("".join(lines))
+
+
+def test_read_benisse_network_synthetic_upper_triangle(tmp_path):
+    A = np.array([
+        [0.0, 0.5, 0.0, 0.0],
+        [0.5, 0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0],
+    ])
+    rows = [("bc0", "IGHV1", "IGHJ1", "CARAA"), ("bc1", "IGHV2", "IGHJ2", "CARBB"),
+            ("bc2", "IGHV3", "IGHJ3", "CARCC"), ("bc3", "IGHV4", "IGHJ4", "CARDD")]
+    _write_fake_outputs(tmp_path, A, rows)
+
+    res = bb.read_benisse_network(tmp_path)
+    assert res.node_ids == [
+        "IGHV1_CARAA_IGHJ1", "IGHV2_CARBB_IGHJ2",
+        "IGHV3_CARCC_IGHJ3", "IGHV4_CARDD_IGHJ4",
+    ]
+    assert res.directed is False
+    assert res.n_edges == 2  # (0,1) and (1,2), upper triangle only
+    assert np.all(res.row <= res.col)
+    coo = res.to_coo().toarray()
+    assert coo[0, 1] == 0.5 and coo[1, 2] == 1.0
+    aa.validate_network_result(res)  # schema-valid
+
+
+def test_read_benisse_network_rejects_asymmetric(tmp_path):
+    A = np.array([[0.0, 0.5], [0.9, 0.0]])  # not symmetric
+    _write_fake_outputs(tmp_path, A, [("b0", "V", "J", "C0"), ("b1", "V", "J", "C1")])
+    with pytest.raises(ValueError, match="symmetric"):
+        bb.read_benisse_network(tmp_path)
+
+
+def test_read_benisse_network_rejects_dim_mismatch(tmp_path):
+    A = np.zeros((3, 3))
+    _write_fake_outputs(tmp_path, A, [("b0", "V", "J", "C0"), ("b1", "V", "J", "C1")])
+    with pytest.raises(ValueError, match="!="):
+        bb.read_benisse_network(tmp_path)
+
+
+def test_read_benisse_network_no_edges(tmp_path):
+    A = np.zeros((3, 3))
+    rows = [("b0", "V1", "J1", "C0"), ("b1", "V2", "J2", "C1"), ("b2", "V3", "J3", "C2")]
+    _write_fake_outputs(tmp_path, A, rows)
+    res = bb.read_benisse_network(tmp_path)
+    assert res.n_nodes == 3 and res.n_edges == 0
+    aa.validate_network_result(res)
+
+
+def test_read_benisse_network_single_node(tmp_path):
+    # np.loadtxt returns a 0-d scalar for a 1x1 matrix; must still parse.
+    _write_fake_outputs(tmp_path, np.zeros((1, 1)), [("b0", "V", "J", "C0")])
+    res = bb.read_benisse_network(tmp_path)
+    assert res.n_nodes == 1 and res.n_edges == 0
+    assert res.node_ids == ["V_C0_J"]
+
+
+def test_read_benisse_network_rejects_nonzero_diagonal(tmp_path):
+    A = np.array([[5.0, 0.0], [0.0, 0.0]])  # symmetric, finite, self-loop
+    _write_fake_outputs(tmp_path, A, [("b0", "V", "J", "C0"), ("b1", "V", "J", "C1")])
+    with pytest.raises(ValueError, match="diagonal"):
+        bb.read_benisse_network(tmp_path)
+
+
+def test_read_benisse_network_rejects_non_finite(tmp_path):
+    A = np.array([[0.0, np.nan], [np.nan, 0.0]])  # structurally symmetric NaN
+    _write_fake_outputs(tmp_path, A, [("b0", "V", "J", "C0"), ("b1", "V", "J", "C1")])
+    with pytest.raises(ValueError, match="non-finite"):
+        bb.read_benisse_network(tmp_path)
+
+
+def test_read_benisse_network_rejects_duplicate_clone_keys(tmp_path):
+    A = np.zeros((2, 2))
+    # identical v/j/cdr3 -> identical clone keys -> non-unique node_ids
+    _write_fake_outputs(tmp_path, A, [("b0", "V", "J", "SAME"), ("b1", "V", "J", "SAME")])
+    with pytest.raises(ValueError, match="unique"):
+        bb.read_benisse_network(tmp_path)
+
+
+def test_run_benisse_r_missing_rscript(tmp_path):
+    for name in ("exp.csv", "contigs.csv", "encoded.csv", "Benisse.R"):
+        (tmp_path / name).write_text("x")
+    with pytest.raises(FileNotFoundError, match="Rscript"):
+        bb.run_benisse_r(
+            tmp_path / "exp.csv", tmp_path / "contigs.csv", tmp_path / "encoded.csv",
+            tmp_path / "out", benisse_r=tmp_path / "Benisse.R",
+            rscript="definitely-not-a-real-binary-xyz",
+        )
+
+
+# --- real oracle: parse the committed example reference outputs ------------
+
+
+@pytest.mark.skipif(
+    not (EXAMPLE / "sparse_graph.txt").exists(),
+    reason="committed example reference outputs not present",
+)
+def test_parse_committed_example_reference_outputs():
+    res = bb.read_benisse_network(EXAMPLE)
+    # Ground truth measured from the committed reference outputs.
+    assert res.n_nodes == 1494
+    assert res.n_edges == 1691          # upper-triangle edges of the symmetric A
+    assert len(set(res.node_ids)) == res.n_nodes  # clone keys unique
+    assert res.weight.min() >= 0.5 and res.weight.max() <= 1.0
+    assert np.all(res.row < res.col)    # strictly upper-triangular (no self-loops)
+    aa.validate_network_result(res)
+
+
+# --- slow end-to-end: encode + run the unmodified R core ------------------
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    os.environ.get("BENISSE_RUN_SLOW_TESTS") != "1",
+    reason="set BENISSE_RUN_SLOW_TESTS=1 to run the multi-minute R core",
+)
+@pytest.mark.skipif(shutil.which("Rscript") is None, reason="Rscript not available")
+def test_run_pipeline_matches_reference_edge_set(tmp_path):
+    result = bb.run_pipeline(
+        EXAMPLE / "10x_NSCLC.csv",
+        EXAMPLE / "10x_NSCLC_exp.csv",
+        EXAMPLE / "10x_NSCLC_contigs.csv",
+        tmp_path / "run",
+        bb.BenisseRParams(),  # example defaults (lambda2=1610)
+        cuda=False,
+    )
+    reference = bb.read_benisse_network(EXAMPLE)
+    assert result.node_ids == reference.node_ids
+    got = set(zip(result.row.tolist(), result.col.tolist()))
+    want = set(zip(reference.row.tolist(), reference.col.tolist()))
+    assert got == want  # exact discrete edge-set agreement with the R oracle


### PR DESCRIPTION
## What

Phase 4c: an interim Python→R bridge that exposes the Benisse core from Python as **import-and-call**, without betting correctness on an unproven port. It runs the **unmodified** `Benisse.R` as a subprocess and parses its outputs into the Phase 4b `BenisseNetworkResult` schema. The public/scverse API and the Python core port (4d/4e) come later; this is the "end-to-end Python UX around the R oracle" step from `UPDATE_PLAN.md`.

Includes fixes from a fresh-context audit (no blockers were found; the load-bearing contracts — arg order, numeric formatting, output parsing, encoder/R seams — were verified correct and the example numbers independently re-derived).

## Module (`benisse_bridge.py`, internal/pre-API)

- `BenisseRParams` + `run_benisse_r` — assemble and run `Rscript Benisse.R …` (args `exp/contigs/encoded/out` + `lambda2,gamma,max_iter,lambda1,rho,m,stop_cutoff`); clear errors on missing inputs, missing `Rscript`, and non-zero R exit (captured stderr). subprocess, not rpy2 (fragile on this stack); the R call is hidden behind one Python function.
- `encode_bcr_csv` — encoder via `from AchillesEncoder import encode_bcr` (import, not CLI).
- `read_benisse_network` (+ `read_sparse_graph`, `read_clone_annotation`, `clone_keys`) — parse `sparse_graph.txt` (`results$A`) and `clone_annotation.csv` into a validated `BenisseNetworkResult`. Nodes are the deduplicated **clone keys** `v_gene_cdr3_j_gene` taken from the R side (honouring the 4b node-identity correction), edges are the upper triangle of the symmetric `A`. Asserts `A` square/finite/symmetric/zero-diagonal/dimension-aligned; handles 1-node and no-edge graphs.
- `run_pipeline` — end-to-end: encode → run R → parse.

## Verification

- Fast suite: **15 passed, 1 skipped** in `benisse-scirpy022`. Fast tests parse the committed `example/` reference outputs — real R-oracle validation without running R (re-derived: 1494 nodes, 1691 undirected edges, weights [0.5, 1.0]).
- Slow end-to-end (`BENISSE_RUN_SLOW_TESTS=1`, ~16 min): the full encode + unmodified `Benisse.R` pipeline reproduced the reference **edge set exactly** (discrete edge-set agreement, 1691 edges).

## Scope / coordination

- Adds only `benisse_bridge.py`, `tests/test_benisse_bridge.py`, `PHASE4C_NOTES.md`. No change to `AchillesEncoder.py`, `Benisse.R`, `R/*`, `airr_adapter.py`, or the Phase 4a/4b tests.
- **Deferred (documented in `PHASE4C_NOTES.md`):** building `exp`/`contigs` CSVs *from a MuData object* — the fragile silent-error surface (R `make.names` barcode join, IGH-only clone key, `is_cell`/`high_confidence`/`full_length` flags AIRR objects don't carry).
- **For Phase 4d (in parallel):** `read_benisse_network` is the shared oracle parser; express the parity gate as edge-set equality on `BenisseNetworkResult` (as the slow test does). `run_pipeline`/`run_benisse_r` → `BenisseNetworkResult` is the seam the port slots into behind the same signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
