### PR TITLE
Add Python post-analysis and scientific plots

### DIFF
--- a/PHASE2_NOTES.md
+++ b/PHASE2_NOTES.md
@@ -1,0 +1,69 @@
+# Phase 2 Python post-analysis and plots
+
+Status: implemented as an **internal, implementation-neutral plotting layer** on
+`feat/python-post-analysis-plots`. It consumes the shared `BenisseNetworkResult` contract and
+therefore works with the supported Phase 4c R bridge or the experimental corrected Python core.
+It does not change which numerical implementation is the default.
+
+## What was delivered
+
+- `benisse_plotting.py`:
+  - validates and aligns the network, clone annotation, latent-distance matrix, and optional
+    20-dimensional encoder embedding;
+  - reconstructs the V/J-family candidate graph used by `R/initiation.R`;
+  - calculates true connected components and the retained-candidate-edge ratio;
+  - reproduces the clone-level expression-distance calculation from `R/initiation.R`, including
+    variable-gene selection, ten-PC cell distances, clone aggregation, and legacy scaling;
+  - reproduces `R/post_analysis.R::testCor` median aggregation and Spearman statistics, including
+    its directed-edge convention and remainder-bin behavior;
+  - plots the encoder embedding with graph edges using PCA, optional deterministic UMAP, or
+    deterministic t-SNE coordinates;
+  - colors nodes by clone size, V/J family, or learned graph component;
+  - plots latent distances by graph relationship, clone-size/component diagnostics, edge
+    retention, and expression–BCR coupling;
+  - writes four Python PDFs with `python_` prefixes so the committed R oracle plots are never
+    overwritten.
+- `tests/test_benisse_plotting.py` covers input validation, graph reconstruction, components,
+  pair classification, deterministic projection, clone-expression aggregation, correlations,
+  empty graphs, all node-color modes, PDF rendering, and the complete committed example.
+- `tests/fixtures/export_post_analysis_oracle.R` exports only the R quantities required for
+  scientific parity checks; it does not alter production R code or committed outputs.
+
+## Parity decisions
+
+- Learned undirected edges and latent-distance categories are plotted once per unique node pair.
+  R duplicates symmetric pairs; removing the duplicate affects rendering cost, not the
+  distributions.
+- Coupling statistics intentionally retain R's directed duplication and exact bin construction,
+  because changing those details changes the reported Spearman values.
+- Clone-level expression matrices can have nonzero diagonals: expanded clones aggregate
+  distances between distinct cells belonging to the same clone. This is validated rather than
+  incorrectly forced to ordinary zero-diagonal distance semantics.
+- Graph-component colors use SciPy's actual connected components. The old `graph_label` column
+  remains readable as annotation, but is not trusted as the component algorithm.
+- The default layout remains PCA for direct continuity with the R plot. UMAP and t-SNE are
+  opt-in views and must not be interpreted as numerical-core outputs.
+
+## Generate plots
+
+After a standard Benisse run:
+
+```python
+import benisse_plotting as bp
+
+paths = bp.generate_post_analysis_plots(
+    out_dir="example",
+    encoded_csv="example/encoded_10x_NSCLC.csv",
+    destination="/tmp/benisse-python-plots",
+)
+```
+
+This produces:
+
+- `python_connectionplot.pdf`
+- `python_latent_distance_groups.pdf`
+- `python_network_summary.pdf`
+- `python_coupling_correlation.pdf` when cleaned expression and clonality labels are present
+
+The module is still internal. Public names, Scanpy-style plotting conventions, return types,
+and CLI exposure remain Phase 4e decisions.

--- a/UPDATE_PLAN.md
+++ b/UPDATE_PLAN.md
@@ -1,6 +1,6 @@
 # Benisse Update Plan
 
-Status: LIVING PLAN — Phase 4c merged; Phase 4d locally validated, default decision pending
+Status: LIVING PLAN — Phase 2 Python plots complete; numerical-core default decision pending
 Date: 2026-07-18
 
 Benisse is a two-stage BCR analysis tool: a Python/torch encoder embeds BCR CDR3H
@@ -45,11 +45,27 @@ verified), **ACTIVE** (current branch), **PENDING** (ready but not started), **D
 | Phase 4b AnnData/AIRR I/O | **DONE; audit hardened** | PR #17 added the contract and PR #19 merged its fresh-context hardening into `develop/v2-modernization` at `ac52d61`. Track Awkward's experimental support and MuData 0.4's upcoming `.update()` behavior before lifting versions. |
 | Phase 4c Python→R bridge | **DONE; MERGED** | PR #21 merged the standard-CSV encoder→R→`BenisseNetworkResult` bridge into `develop/v2-modernization` at `0ceb21e`; it remains the supported execution path. |
 | Phase 4d R-core port | **LOCALLY VALIDATED; DEFAULT DECISION PENDING** | Corrected kernels pass small oracles plus three complete Stephenson samples (92–427 nodes) and the 1,494-node committed NSCLC example. The port converges with successful optimizers and highly concordant latent geometry, but prunes legacy edges (up to 11/33 on AP4); do not make it default without an explicit migration decision. |
-| Phase 2 Python plots | **DEFERRED** | Implement after 4d so plots use the lasting Python result object. |
+| Phase 2 Python plots | **DONE; PR PENDING** | Implementation-neutral plotting reproduces R expression-distance/coupling statistics and renders network, latent-distance, clone-size, component, and edge-retention views from `BenisseNetworkResult`. Focused: 11 passed; combined: 89 passed, 4 explicit skips. |
 | Phase 4e packaging/CLI/release hardening | **DEFERRED** | Package only after the scientific API and data model stabilize. |
 | Phase 3 tutorial | **DEFERRED** | Write against the final 4e CLI rather than documenting transitional entry points. |
 
 ### Work log
+
+- **2026-07-18 — Phase 2 Python post-analysis and plots
+  (`feat/python-post-analysis-plots`).** Added an internal implementation-neutral plotting layer
+  over `BenisseNetworkResult`, retaining the Phase 4c R bridge as the default core. It aligns
+  clone annotation, latent distances, and encoder embeddings; reconstructs V/J candidate support
+  and true connected components; and ports the clone-expression distance and `testCor`
+  aggregation algorithms. Added PCA, optional deterministic UMAP/t-SNE network layouts; clone
+  size, V/J, and component color modes; latent-distance relationship boxes; clone/component and
+  retained-edge diagnostics; and expression–BCR coupling scatter/statistics. Python PDFs use
+  separate names and never replace the R oracle. A live R fixture confirms the complete
+  1,494-node NSCLC expression-distance matrix within `rtol=2e-6`, exact candidate support, and
+  both Spearman results within `2e-8`. The audit captured two legacy semantics: within-clone
+  aggregation can make `master_dist_e`'s diagonal nonzero, and the final correlation-bin
+  remainder is appended to the last full group. Focused Phase 2 result: 11 passed in 32.94s;
+  combined fast result: 89 passed, 4 explicit local/slow skips in 41.39s. Generated full-example
+  PDFs were raster-inspected successfully. Details and usage are in `PHASE2_NOTES.md`.
 
 - **2026-07-18 — Phase 4d guarded real-data hardening after Phase 4c merge.** Merged the
   Phase 4c bridge (PR #21, `0ceb21e`) into `feat/python-r-core-port` and reused its shared
@@ -269,15 +285,16 @@ is compared object-by-object and PDFs by rasterized pages because their metadata
   manifest; include the old blob in the later coordinated history rewrite.
 
 ## Phase 2 — New plotting functions
-NOTE (re-sequenced): all current plotting is R/ggplot (`post_analysis.R` `checkDist`,
-`plotClusters`) operating on the R `Benisse_results` RData object, which won't exist in
-Python until 4d. To avoid building throwaway R plotting that Phase 4 obsoletes, either
-(a) defer the *new* plots to after 4d and write them in Python, or (b) explicitly accept
-these as interim R plots and don't invest in a "reusable module" twice. Recommended: (a),
-with only minimal fixes to existing R plots now.
-Planned plots: clonotype network colored by clone size / V-J family / graph cluster;
-UMAP/t-SNE of latent space with graph edges; clone-size + edges-remaining diagnostics;
-expression-vs-latent-distance correlation scatter (expose `testCor`).
+**DONE on `feat/python-post-analysis-plots`; PR pending.** The implementation-neutral layer consumes
+`BenisseNetworkResult`, annotation, latent distances, cleaned expression, clonality labels, and
+the encoder embedding rather than depending on an RData object. Delivered scope includes:
+clonotype networks colored by clone size / V-J family / true graph component; PCA plus optional
+UMAP/t-SNE coordinates with graph edges; clone-size, component-size, and edges-remaining
+diagnostics; the latent-distance relationship groups from `checkDist`; and expression-vs-latent
+and expression-vs-encoder coupling scatter/statistics from `testCor`. The Python reconstruction
+of `master_dist_e`, V/J candidate support, and both coupling correlations is checked directly
+against the committed R oracle. Generated PDFs use distinct `python_` names. See
+`PHASE2_NOTES.md`; public plotting API/CLI choices remain deferred to 4e.
 
 ## Phase 3 — User-friendliness & tutorials
 - Rewrite README against actual filenames and the conda/CPU workflow.
@@ -314,18 +331,17 @@ than designing the packaging from scratch.
   heavy-chain selection and field mapping, includes a reproducible fixture derivation script,
   and tests embedding writes without destroying the AIRR modality. Do not publish the
   downloaded/derived objects until their processed-data redistribution license is confirmed.
-- **ACTIVE — 4c interim Python→R bridge.** Expose the core from Python via a thin subprocess/rpy2
-  wrapper around the UNMODIFIED `Benisse.R`, so users get end-to-end Python UX without
-  betting correctness on an unproven port. Treat this as an internal/scientific interface;
-  defer the polished public CLI.
-- **EXPERIMENTAL — 4d R-core port; small-fixture scope complete, scale validation deferred.**
-  The Python core uses the mathematically correct symmetric-edge parameterization and is tested
-  against a corrected, test-only R implementation on small deterministic cases. Component
-  kernels require explicit tight tolerances, every inner optimizer must report success, and
-  scientific invariants and node-order equivariance are enforced. Full example/cohort edge-set,
-  latent-geometry, and downstream biological equivalence remain unverified and must not be
-  inferred from the component tests. Do not switch the default execution path or retire R until
-  compute and representative data are available for that work.
+- **DONE — 4c interim Python→R bridge.** A thin subprocess wrapper around `Benisse.R` gives
+  users end-to-end Python UX without betting correctness on the corrected port. It remains an
+  internal/scientific interface; the polished public CLI is deferred.
+- **EXPERIMENTAL — 4d R-core port; locally validated, default decision pending.** The Python core
+  uses the mathematically correct symmetric-edge parameterization and is tested against a
+  corrected, test-only R implementation plus three complete Stephenson samples and the
+  1,494-node paper example. Component kernels require explicit tight tolerances, every inner
+  optimizer must report success, and scientific invariants and node-order equivariance are
+  enforced. Runs converge with highly concordant latent geometry, but the corrected graph prunes
+  legacy edges (most materially 11 of 33 on AP4). Do not switch the default execution path or
+  retire R without an explicit scientific migration decision and regenerated expectations.
   **Why port ADMM rather than replace it:** the ADMM sparse-graph is the differentiator —
   convex, interpretable, and it guarantees the learned graph is a strict sparse subset of the
   crude graph (`benisse_context.md` §5). BiGCN's GCN fusion (`bigcn_context.md`) is a known
@@ -559,11 +575,13 @@ ADMM" bet and answers the reviewer/user question "why Benisse over BiGCN/mvTCR?"
 **DONE:** Phase 1 fixes + hash baseline + pandas-pin lift + AIRR/Scirpy fixture groundwork +
 Phase 4a scientific parity harness and callable encoder boundary.
 
+**DONE:** Phase 2 Python post-analysis and plots now operate on the shared result contract without
+depending on which numerical core produced it.
+
 **NEXT DECISION:** keep the merged Phase 4c R bridge as the v2 default, or deliberately adopt
 the corrected Phase 4d Python core with scientific migration notes and regenerated reference
 expectations. Local validation establishes numerical stability but also shows real edge pruning,
-so the default must not change implicitly. After that decision, proceed to Phase 2 Python plots
-against the shared result object → 4e (package,
+so the default must not change implicitly. After that decision, proceed to 4e (package,
 public CLI, CI, tutorial, migration notes, and Seurat bridge) → competitive
 benchmark vs BiGCN (gated on paper access) → Phase 5. Merge the integration branch to `main`
 and tag v2 only after the release gates below pass. Coordinate the remaining large-asset move

--- a/benisse_plotting.py
+++ b/benisse_plotting.py
@@ -1,0 +1,494 @@
+"""Internal Python post-analysis and plotting for Benisse results.
+
+The functions consume the implementation-neutral ``BenisseNetworkResult``
+contract. They do not select the R or corrected-Python numerical core and are
+not yet a promised public plotting API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import tempfile
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.collections import LineCollection
+from scipy import sparse
+from scipy.sparse.csgraph import connected_components
+from scipy.spatial.distance import pdist, squareform
+from scipy.stats import spearmanr
+from sklearn.decomposition import PCA
+
+import airr_adapter as aa
+import benisse_bridge as bridge
+
+
+DISTANCE_LABELS = (
+    "Connected in\nBCR networks",
+    "Not connected,\nsharing V/J genes",
+    "Not connected,\nnot sharing V/J genes",
+)
+PLOT_FILENAMES = {
+    "connection": "python_connectionplot.pdf",
+    "latent_distance": "python_latent_distance_groups.pdf",
+    "network_summary": "python_network_summary.pdf",
+    "coupling": "python_coupling_correlation.pdf",
+}
+
+
+@dataclass(frozen=True)
+class BenissePlotData:
+    network: aa.BenisseNetworkResult
+    annotation: pd.DataFrame
+    latent_distances: np.ndarray
+    embedding: np.ndarray | None = None
+
+
+def _validate_square_distances(
+    values, n_nodes: int, name: str, *, require_zero_diagonal=True
+) -> np.ndarray:
+    matrix = np.atleast_2d(np.asarray(values, dtype="float64"))
+    if matrix.shape != (n_nodes, n_nodes):
+        raise ValueError(f"{name} shape {matrix.shape} != ({n_nodes}, {n_nodes})")
+    if not np.isfinite(matrix).all():
+        raise ValueError(f"{name} contains non-finite values")
+    if not np.allclose(matrix, matrix.T, rtol=0, atol=1e-8):
+        raise ValueError(f"{name} must be symmetric")
+    if require_zero_diagonal and not np.allclose(np.diag(matrix), 0, rtol=0, atol=1e-8):
+        raise ValueError(f"{name} must have a zero diagonal")
+    return matrix
+
+
+def _read_embedding(encoded_csv, annotation: pd.DataFrame) -> np.ndarray:
+    encoded = pd.read_csv(encoded_csv)
+    if "index" not in encoded.columns:
+        raise ValueError("encoded CSV is missing its CDR3 'index' column")
+    feature_columns = [str(i) for i in range(20)]
+    missing = set(feature_columns) - set(encoded.columns)
+    if missing:
+        raise ValueError(f"encoded CSV is missing feature columns {sorted(missing)}")
+    if encoded["index"].duplicated().any():
+        raise ValueError("encoded CSV contains ambiguous duplicate CDR3 values")
+    lookup = encoded.set_index("index")[feature_columns]
+    missing_cdr3 = sorted(set(annotation["cdr3"].astype(str)) - set(lookup.index.astype(str)))
+    if missing_cdr3:
+        raise ValueError(f"encoded CSV is missing {len(missing_cdr3)} annotated CDR3 values")
+    matrix = lookup.loc[annotation["cdr3"].astype(str)].to_numpy(dtype="float64")
+    if not np.isfinite(matrix).all():
+        raise ValueError("encoded embedding contains non-finite values")
+    return matrix
+
+
+def read_plot_data(out_dir, *, encoded_csv=None) -> BenissePlotData:
+    """Read standard Benisse outputs into a validated plotting bundle."""
+    out_dir = Path(out_dir)
+    network = bridge.read_benisse_network(out_dir)
+    annotation = bridge.read_clone_annotation(out_dir)
+    node_ids = bridge.clone_keys(annotation)
+    if node_ids != network.node_ids:
+        raise ValueError("annotation order does not match network node order")
+    latent = _validate_square_distances(
+        np.loadtxt(out_dir / bridge.OUTPUT_FILES["latent_dist"]),
+        network.n_nodes,
+        "latent distances",
+    )
+    embedding = _read_embedding(encoded_csv, annotation) if encoded_csv else None
+    return BenissePlotData(network, annotation, latent, embedding)
+
+
+def symmetric_adjacency(network: aa.BenisseNetworkResult, *, binary=False) -> sparse.csr_matrix:
+    """Return the full symmetric adjacency represented by upper-triangle edges."""
+    aa.validate_network_result(network)
+    if network.directed:
+        raise ValueError("Phase 2 plots currently require an undirected network")
+    values = np.ones(network.n_edges) if binary else np.asarray(network.weight, dtype="float64")
+    matrix = sparse.coo_matrix(
+        (
+            np.r_[values, values],
+            (np.r_[network.row, network.col], np.r_[network.col, network.row]),
+        ),
+        shape=(network.n_nodes, network.n_nodes),
+    )
+    return matrix.tocsr()
+
+
+def crude_graph(annotation: pd.DataFrame) -> np.ndarray:
+    """Reconstruct R ``initiation.R``'s V/J-family candidate graph."""
+    required = {"v_gene", "j_gene"}
+    missing = required - set(annotation.columns)
+    if missing:
+        raise ValueError(f"annotation missing columns {sorted(missing)}")
+    families = (
+        annotation["v_gene"].fillna("").astype(str)
+        + "\x1f"
+        + annotation["j_gene"].fillna("").astype(str)
+    ).to_numpy()
+    candidate = families[:, None] == families[None, :]
+    np.fill_diagonal(candidate, False)
+    return candidate
+
+
+def component_labels(network: aa.BenisseNetworkResult) -> tuple[np.ndarray, np.ndarray]:
+    """Return deterministic connected-component labels and their sizes."""
+    adjacency = symmetric_adjacency(network, binary=True)
+    count, raw = connected_components(adjacency, directed=False)
+    sizes = np.bincount(raw, minlength=count)
+    order = sorted(range(count), key=lambda i: (-sizes[i], int(np.flatnonzero(raw == i)[0])))
+    remap = np.empty(count, dtype="int64")
+    remap[order] = np.arange(count)
+    labels = remap[raw]
+    return labels, np.bincount(labels, minlength=count)
+
+
+def pca_coordinates(embedding) -> np.ndarray:
+    """Project a node embedding to two deterministic principal-component axes."""
+    matrix = np.asarray(embedding, dtype="float64")
+    if matrix.ndim != 2 or matrix.shape[0] < 1:
+        raise ValueError("embedding must be a non-empty two-dimensional matrix")
+    if not np.isfinite(matrix).all():
+        raise ValueError("embedding contains non-finite values")
+    if matrix.shape[0] == 1:
+        return np.zeros((1, 2), dtype="float64")
+    n_components = min(2, matrix.shape[0], matrix.shape[1])
+    coordinates = PCA(n_components=n_components, svd_solver="full").fit_transform(matrix)
+    if n_components == 1:
+        coordinates = np.column_stack([coordinates[:, 0], np.zeros(matrix.shape[0])])
+    for axis in range(2):
+        pivot = int(np.argmax(np.abs(coordinates[:, axis])))
+        if coordinates[pivot, axis] < 0:
+            coordinates[:, axis] *= -1
+    return coordinates
+
+
+def embedding_coordinates(embedding, *, method="pca", random_state=0) -> np.ndarray:
+    """Return deterministic PCA, UMAP, or t-SNE node coordinates."""
+    matrix = np.asarray(embedding, dtype="float64")
+    if method == "pca":
+        return pca_coordinates(matrix)
+    if matrix.ndim != 2 or matrix.shape[0] < 3 or not np.isfinite(matrix).all():
+        raise ValueError(f"{method} requires at least three finite embedding rows")
+    if method == "umap":
+        if "NUMBA_CACHE_DIR" not in os.environ:
+            cache_dir = Path(tempfile.gettempdir()) / "benisse-numba-cache"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            os.environ["NUMBA_CACHE_DIR"] = str(cache_dir)
+        try:
+            from umap import UMAP
+        except ImportError as exc:
+            raise ImportError("UMAP plotting requires umap-learn") from exc
+        return UMAP(n_components=2, random_state=random_state).fit_transform(matrix)
+    if method == "tsne":
+        from sklearn.manifold import TSNE
+
+        perplexity = min(30.0, max(2.0, (matrix.shape[0] - 1) / 3))
+        return TSNE(
+            n_components=2,
+            init="pca",
+            learning_rate="auto",
+            perplexity=perplexity,
+            random_state=random_state,
+        ).fit_transform(matrix)
+    raise ValueError("method must be pca, umap, or tsne")
+
+
+def latent_distance_groups(data: BenissePlotData) -> dict[str, np.ndarray]:
+    """Partition latent distances by learned-edge and candidate-graph status."""
+    n = data.network.n_nodes
+    latent = _validate_square_distances(data.latent_distances, n, "latent distances")
+    learned = symmetric_adjacency(data.network, binary=True).toarray().astype(bool)
+    candidate = crude_graph(data.annotation)
+    upper = np.triu(np.ones((n, n), dtype=bool), k=1)
+    masks = (
+        learned & upper,
+        ~learned & candidate & upper,
+        ~candidate & upper,
+    )
+    return {label: latent[mask] for label, mask in zip(DISTANCE_LABELS, masks)}
+
+
+def edge_retention_ratio(data: BenissePlotData) -> float:
+    candidates = int(np.count_nonzero(np.triu(crude_graph(data.annotation), k=1)))
+    if candidates == 0:
+        return float("nan")
+    return data.network.n_edges / candidates
+
+
+def clone_expression_distances(cleaned_exp, clonality_labels, node_ids) -> np.ndarray:
+    """Reproduce ``initiation.R``'s clone-level expression-distance matrix.
+
+    ``cleaned_exp`` is genes x cells and ``clonality_labels`` has one clone key
+    per cell. The calculation selects the most variable expression decile,
+    performs the same unscaled 10-PC projection, sums cell distances by clone,
+    and applies the legacy normalization.
+    """
+    if isinstance(cleaned_exp, (str, Path)):
+        expression = pd.read_csv(cleaned_exp, sep=r"\s+", index_col=0)
+    else:
+        expression = pd.DataFrame(cleaned_exp).copy()
+    if isinstance(clonality_labels, (str, Path)):
+        labels = pd.read_csv(clonality_labels, header=None).iloc[:, 0].astype(str).to_numpy()
+    else:
+        labels = np.asarray(clonality_labels, dtype=str)
+    values = expression.to_numpy(dtype="float64")
+    if values.ndim != 2 or values.shape[1] != labels.size:
+        raise ValueError("expression columns and clonality labels must have equal length")
+    if labels.size < 2 or not np.isfinite(values).all():
+        raise ValueError("expression data require at least two finite cells")
+    deviations = np.std(values, axis=1, ddof=1)
+    keep = deviations > np.quantile(deviations, 0.9)
+    if np.count_nonzero(keep) < 1:
+        raise ValueError("no genes remain after variable-gene selection")
+    cell_matrix = values[keep].T
+    n_components = min(10, cell_matrix.shape[0], cell_matrix.shape[1])
+    scores = PCA(n_components=n_components, svd_solver="full").fit_transform(cell_matrix)
+    cell_distances = squareform(pdist(scores))
+
+    unique_labels = np.asarray(sorted(set(labels)))
+    indicator = sparse.csr_matrix(
+        (
+            np.ones(labels.size),
+            (np.arange(labels.size), np.searchsorted(unique_labels, labels)),
+        ),
+        shape=(labels.size, unique_labels.size),
+    )
+    aggregated = np.asarray(indicator.T @ cell_distances @ indicator)
+    scaler = 4 * aggregated.sum() / (labels.size * (labels.size - 1))
+    if scaler <= 0 or not np.isfinite(scaler):
+        raise ValueError("expression-distance scaling is zero or non-finite")
+    clone_sizes = np.asarray(indicator.sum(axis=0)).ravel()
+    normalized = aggregated / clone_sizes[:, None] / clone_sizes[None, :] / scaler
+    positions = {name: i for i, name in enumerate(unique_labels)}
+    missing = [name for name in node_ids if name not in positions]
+    if missing:
+        raise ValueError(f"clonality labels are missing {len(missing)} graph nodes")
+    order = np.asarray([positions[name] for name in node_ids])
+    result = normalized[np.ix_(order, order)]
+    return (result + result.T) / 2
+
+
+def bcr_embedding_distances(embedding) -> np.ndarray:
+    matrix = np.asarray(embedding, dtype="float64")
+    if matrix.ndim != 2 or not np.isfinite(matrix).all():
+        raise ValueError("embedding must be a finite two-dimensional matrix")
+    return squareform(pdist(matrix))
+
+
+def coupling_data(
+    expression_distances,
+    latent_distances,
+    embedding_distances,
+    network: aa.BenisseNetworkResult,
+    *,
+    target_points=300,
+) -> tuple[pd.DataFrame, dict[str, float]]:
+    """Reproduce the data reduction and Spearman statistics in R ``testCor``."""
+    if target_points < 1:
+        raise ValueError("target_points must be positive")
+    n = network.n_nodes
+    matrices = [
+        _validate_square_distances(
+            matrix, n, name, require_zero_diagonal=(name != "expression distances")
+        )
+        for matrix, name in (
+            (expression_distances, "expression distances"),
+            (latent_distances, "latent distances"),
+            (embedding_distances, "embedding distances"),
+        )
+    ]
+    learned = symmetric_adjacency(network, binary=True).toarray().astype(bool)
+    if not learned.any():
+        empty = pd.DataFrame(columns=["expression", "latent", "embedding"])
+        return empty, {"expression_latent": float("nan"), "expression_embedding": float("nan")}
+    values = [matrix[learned] for matrix in matrices]
+    order = np.argsort(values[0], kind="stable")
+    values = [value[order] for value in values]
+    group_size = len(order) // target_points
+    if group_size < 5:
+        group_size = len(order) // 50
+    group_size = max(1, group_size)
+    full_groups = len(order) // group_size
+    groups = np.repeat(np.arange(full_groups), group_size)
+    if groups.size < len(order):
+        # R appends the remainder to its final complete group rather than
+        # creating a smaller trailing group.
+        groups = np.r_[groups, np.repeat(full_groups - 1, len(order) - groups.size)]
+    frame = pd.DataFrame(
+        {"expression": values[0], "latent": values[1], "embedding": values[2], "group": groups}
+    )
+    reduced = frame.groupby("group", sort=True).median(numeric_only=True).reset_index(drop=True)
+    correlations = {
+        "expression_latent": float(spearmanr(reduced["expression"], reduced["latent"]).statistic),
+        "expression_embedding": float(
+            spearmanr(reduced["expression"], reduced["embedding"]).statistic
+        ),
+    }
+    return reduced, correlations
+
+
+def _node_colors(data: BenissePlotData, color_by: str):
+    annotation = data.annotation
+    if color_by == "clone_size":
+        if "clsize" not in annotation:
+            raise ValueError("annotation has no clsize column")
+        values = pd.to_numeric(annotation["clsize"], errors="raise").to_numpy(dtype="float64")
+        return np.log2(values + 1), "viridis", "log2(clone size + 1)"
+    if color_by == "vj_family":
+        labels = annotation["v_gene"].astype(str) + " / " + annotation["j_gene"].astype(str)
+    elif color_by == "graph_component":
+        components, sizes = component_labels(data.network)
+        labels = pd.Series(
+            ["singleton" if sizes[item] == 1 else f"component {item + 1}" for item in components]
+        )
+    else:
+        raise ValueError("color_by must be clone_size, vj_family, or graph_component")
+    codes, _ = pd.factorize(labels, sort=True)
+    return codes, "tab20", color_by.replace("_", " ")
+
+
+def plot_embedding_network(
+    data: BenissePlotData, *, color_by="clone_size", method="pca", random_state=0, ax=None
+):
+    """Plot encoder-PC coordinates and learned graph edges."""
+    if data.embedding is None:
+        raise ValueError("an encoder embedding is required for the connection plot")
+    coordinates = embedding_coordinates(
+        data.embedding, method=method, random_state=random_state
+    )
+    if ax is None:
+        _, ax = plt.subplots(figsize=(7, 7), constrained_layout=True)
+    segments = np.stack([coordinates[data.network.row], coordinates[data.network.col]], axis=1)
+    if len(segments):
+        widths = 0.25 + 0.75 * np.asarray(data.network.weight) / max(data.network.weight)
+        ax.add_collection(LineCollection(segments, colors="0.72", linewidths=widths, alpha=0.45))
+    colors, cmap, color_label = _node_colors(data, color_by)
+    clone_sizes = (
+        pd.to_numeric(data.annotation["clsize"], errors="coerce").fillna(1).to_numpy()
+        if "clsize" in data.annotation else np.ones(data.network.n_nodes)
+    )
+    sizes = 9 + 12 * np.sqrt(clone_sizes.astype("float64"))
+    points = ax.scatter(
+        coordinates[:, 0], coordinates[:, 1], c=colors, cmap=cmap, s=sizes,
+        alpha=0.8, edgecolors="none", zorder=2,
+    )
+    if color_by == "clone_size":
+        ax.figure.colorbar(points, ax=ax, shrink=0.72, label=color_label)
+    axis_prefix = {"pca": "PC", "umap": "UMAP", "tsne": "t-SNE"}[method]
+    ax.set(
+        xlabel=f"Encoder {axis_prefix}1",
+        ylabel=f"Encoder {axis_prefix}2",
+        title="Benisse clonotype network",
+    )
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax
+
+
+def plot_latent_distance_groups(data: BenissePlotData, *, ax=None):
+    """Plot the Python equivalent of R ``checkDist`` using unique node pairs."""
+    groups = latent_distance_groups(data)
+    if ax is None:
+        _, ax = plt.subplots(figsize=(6.5, 4.5), constrained_layout=True)
+    values = [groups[label] for label in DISTANCE_LABELS]
+    positions = np.arange(1, 4)
+    box = ax.boxplot(values, positions=positions, widths=0.5, patch_artist=True, showfliers=False)
+    palette = plt.get_cmap("Dark2")(np.arange(3))
+    for patch, color in zip(box["boxes"], palette):
+        patch.set_facecolor(color)
+        patch.set_alpha(0.65)
+    ax.set_xticks(positions, DISTANCE_LABELS, rotation=20, ha="right")
+    ax.set_ylabel("BCR distances in latent space")
+    ax.set_title("Latent distance by graph relationship")
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax
+
+
+def plot_network_summary(data: BenissePlotData, *, axes=None):
+    """Plot clone-size and connected-component diagnostics."""
+    if axes is None:
+        _, axes = plt.subplots(1, 2, figsize=(8, 3.8), constrained_layout=True)
+    axes = np.asarray(axes).ravel()
+    if axes.size != 2:
+        raise ValueError("network summary requires exactly two axes")
+    clone_sizes = (
+        pd.to_numeric(data.annotation["clsize"], errors="coerce").fillna(1)
+        if "clsize" in data.annotation
+        else pd.Series(np.ones(data.network.n_nodes))
+    )
+    clone_counts = clone_sizes.value_counts().sort_index()
+    axes[0].bar(clone_counts.index, clone_counts.values, color=plt.get_cmap("Dark2")(0))
+    axes[0].set(xlabel="Clone size (cells)", ylabel="Clonotypes", title="Clone-size distribution")
+    _, sizes = component_labels(data.network)
+    component_counts = pd.Series(sizes).value_counts().sort_index()
+    axes[1].bar(component_counts.index, component_counts.values, color=plt.get_cmap("Dark2")(1))
+    ratio = edge_retention_ratio(data)
+    ratio_text = "n/a" if not np.isfinite(ratio) else f"{ratio:.1%}"
+    axes[1].set(
+        xlabel="Nodes per component", ylabel="Components",
+        title=f"Network components\n{data.network.n_edges} edges; {ratio_text} of V/J candidates",
+    )
+    for axis in axes:
+        axis.spines[["top", "right"]].set_visible(False)
+    return axes
+
+
+def plot_coupling_correlation(reduced: pd.DataFrame, correlations: dict[str, float], *, ax=None):
+    """Plot expression distance against latent and original-embedding distance."""
+    required = {"expression", "latent", "embedding"}
+    if required - set(reduced.columns):
+        raise ValueError(f"reduced coupling data must contain {sorted(required)}")
+    if ax is None:
+        _, ax = plt.subplots(figsize=(6, 4.5), constrained_layout=True)
+    ax.scatter(reduced["expression"], reduced["latent"], s=18, alpha=0.7, label="Latent")
+    ax.scatter(
+        reduced["expression"], reduced["embedding"], s=18, alpha=0.7,
+        marker="^", label="Encoder",
+    )
+    ax.set(
+        xlabel="Clone expression distance", ylabel="BCR distance",
+        title=(
+            "Expression–BCR coupling\n"
+            f"Spearman latent={correlations['expression_latent']:.3f}; "
+            f"encoder={correlations['expression_embedding']:.3f}"
+        ),
+    )
+    ax.legend(frameon=False)
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax
+
+
+def generate_post_analysis_plots(out_dir, encoded_csv, destination=None) -> dict[str, Path]:
+    """Generate Python PDFs from a standard completed Benisse output directory."""
+    out_dir = Path(out_dir)
+    destination = Path(destination) if destination else out_dir
+    destination.mkdir(parents=True, exist_ok=True)
+    data = read_plot_data(out_dir, encoded_csv=encoded_csv)
+    generated = {}
+    for key, plotter in (
+        ("connection", plot_embedding_network),
+        ("latent_distance", plot_latent_distance_groups),
+        ("network_summary", plot_network_summary),
+    ):
+        plotter(data)
+        path = destination / PLOT_FILENAMES[key]
+        plt.gcf().savefig(path, bbox_inches="tight")
+        plt.close(plt.gcf())
+        generated[key] = path
+
+    cleaned = out_dir / bridge.OUTPUT_FILES["cleaned_exp"]
+    clonality = out_dir / bridge.OUTPUT_FILES["clonality_label"]
+    if cleaned.exists() and clonality.exists():
+        expression = clone_expression_distances(cleaned, clonality, data.network.node_ids)
+        reduced, correlations = coupling_data(
+            expression,
+            data.latent_distances,
+            bcr_embedding_distances(data.embedding),
+            data.network,
+        )
+        plot_coupling_correlation(reduced, correlations)
+        path = destination / PLOT_FILENAMES["coupling"]
+        plt.gcf().savefig(path, bbox_inches="tight")
+        plt.close(plt.gcf())
+        generated["coupling"] = path
+    return generated

--- a/environment-scirpy022.yml
+++ b/environment-scirpy022.yml
@@ -10,6 +10,10 @@ dependencies:
   - numpy=1.26.4
   # Phase 4d translates R's bounded L-BFGS-B graph update to scipy.optimize.
   - scipy=1.15.3
+  # Phase 2 Python-native scientific plots; umap-learn also enables the
+  # optional nonlinear clonotype-network layout.
+  - matplotlib=3.10.9
+  - umap-learn=0.5.12
   # Pin the last readily available Intel-macOS wheel pair. Without these pins,
   # pip selects Numba 0.66 and attempts an unsupported local OpenMP/LLVM build.
   - numba=0.61.2

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,3 +64,17 @@ BENISSE_RUN_PYTHON_CORE_EXAMPLE=1 conda run -n benisse-scirpy022 \
 For other Stephenson validations, invoke `real_data_validation.py` with one `--sample-id` and
 write outputs under `/tmp`. Do not submit the entire 5k multi-patient object as one graph; the
 tool refuses more than 500 clone nodes unless the guard is deliberately raised.
+
+## Python post-analysis parity
+
+Run the Phase 2 scientific and rendering checks with:
+
+```sh
+conda run -n benisse-scirpy022 python -m pytest tests/test_benisse_plotting.py -v
+```
+
+When R is available, this exports `master_dist_e`, the V/J candidate graph, and the two coupling
+correlations from the committed `Benisse_results.RData` into pytest's temporary directory. The
+Python expression-distance matrix and correlation statistics are then compared directly with
+that oracle. Synthetic checks cover sparse and empty graphs and verify that every Python plot
+writes a nonempty PDF. No generated plot is committed over the reference R PDFs.

--- a/tests/fixtures/export_post_analysis_oracle.R
+++ b/tests/fixtures/export_post_analysis_oracle.R
@@ -1,0 +1,27 @@
+args=commandArgs(trailingOnly=TRUE)
+if(length(args)!=3){
+  stop('usage: Rscript export_post_analysis_oracle.R RESULTS_RDATA ENCODED OUT')
+}
+
+load(args[1])
+source('R/post_analysis.R')
+encoded=read.csv(args[2],stringsAsFactors=FALSE)[,-1]
+encoded=encoded[match(results$meta_dedup$cdr3,encoded$index),]
+t=as.matrix(encoded[,1:20])
+correlations=testCor(
+  results$master_dist_e,results$Q,t,results$sparse_graph,results$hyper_para
+)
+
+dir.create(args[3],recursive=TRUE,showWarnings=FALSE)
+write.table(
+  results$master_dist_e,file=file.path(args[3],'master_dist_e.txt'),
+  quote=FALSE,row.names=FALSE,col.names=FALSE
+)
+write.table(
+  results$SI,file=file.path(args[3],'si.txt'),
+  quote=FALSE,row.names=FALSE,col.names=FALSE
+)
+writeLines(
+  c(as.character(correlations$c1),as.character(correlations$c2)),
+  file.path(args[3],'correlations.txt')
+)

--- a/tests/test_benisse_plotting.py
+++ b/tests/test_benisse_plotting.py
@@ -1,0 +1,208 @@
+"""Scientific and rendering checks for Python Benisse post-analysis."""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import airr_adapter as aa  # noqa: E402
+import benisse_plotting as bp  # noqa: E402
+
+
+EXAMPLE = REPO_ROOT / "example"
+RSCRIPT = shutil.which("Rscript")
+ORACLE_R = REPO_ROOT / "tests" / "fixtures" / "export_post_analysis_oracle.R"
+
+
+def _small_plot_data(with_embedding=True):
+    annotation = pd.DataFrame(
+        {
+            "v_gene": ["V1", "V1", "V1", "V2"],
+            "j_gene": ["J1", "J1", "J1", "J2"],
+            "cdr3": ["C1", "C2", "C3", "C4"],
+            "clsize": [1, 4, 2, 1],
+        }
+    )
+    network = aa.BenisseNetworkResult(
+        node_ids=["V1_C1_J1", "V1_C2_J1", "V1_C3_J1", "V2_C4_J2"],
+        row=np.array([0, 1], dtype=np.int64),
+        col=np.array([1, 2], dtype=np.int64),
+        weight=np.array([0.5, 1.0]),
+    )
+    coordinates = np.array([[0, 0], [1, 0], [3, 0], [7, 0]], dtype=float)
+    latent = np.abs(coordinates[:, 0, None] - coordinates[:, 0])
+    embedding = (
+        np.array([[0, 1, 0], [1, 1, 0], [2, 0, 1], [4, 0, 0]], dtype=float)
+        if with_embedding else None
+    )
+    return bp.BenissePlotData(network, annotation, latent, embedding)
+
+
+def test_adjacency_crude_graph_components_and_retention():
+    data = _small_plot_data()
+    adjacency = bp.symmetric_adjacency(data.network).toarray()
+    candidate = bp.crude_graph(data.annotation)
+    labels, sizes = bp.component_labels(data.network)
+
+    assert np.array_equal(adjacency, adjacency.T)
+    assert adjacency[0, 1] == 0.5 and adjacency[1, 2] == 1.0
+    assert np.count_nonzero(np.triu(candidate, 1)) == 3
+    assert labels.tolist() == [0, 0, 0, 1]
+    assert sizes.tolist() == [3, 1]
+    assert bp.edge_retention_ratio(data) == pytest.approx(2 / 3)
+
+
+def test_latent_distance_groups_use_unique_pairs():
+    groups = bp.latent_distance_groups(_small_plot_data())
+    assert groups[bp.DISTANCE_LABELS[0]].tolist() == [1.0, 2.0]
+    assert groups[bp.DISTANCE_LABELS[1]].tolist() == [3.0]
+    assert sorted(groups[bp.DISTANCE_LABELS[2]].tolist()) == [4.0, 6.0, 7.0]
+
+
+def test_pca_coordinates_are_deterministic_and_handle_one_node():
+    embedding = _small_plot_data().embedding
+    assert np.array_equal(bp.pca_coordinates(embedding), bp.pca_coordinates(embedding))
+    assert bp.pca_coordinates(np.array([[2.0, 3.0]])).shape == (1, 2)
+    with pytest.raises(ValueError, match="non-empty"):
+        bp.pca_coordinates(np.empty((0, 2)))
+    with pytest.raises(ValueError, match="method must"):
+        bp.embedding_coordinates(embedding, method="unknown")
+
+
+def test_clone_expression_distances_are_symmetric_and_node_ordered():
+    expression = pd.DataFrame(
+        np.array(
+            [
+                [0, 1, 2, 3, 4, 5],
+                [5, 4, 3, 2, 1, 0],
+                [0, 0, 1, 1, 3, 3],
+                [1, 4, 1, 4, 1, 4],
+                [2, 3, 5, 7, 11, 13],
+                [1, 1, 2, 3, 5, 8],
+                [8, 5, 3, 2, 1, 1],
+                [1, 0, 0, 1, 0, 1],
+                [2, 4, 8, 16, 32, 64],
+                [3, 1, 4, 1, 5, 9],
+            ],
+            dtype=float,
+        ),
+        columns=[f"cell{i}" for i in range(6)],
+    )
+    labels = np.array(["clone_b", "clone_a", "clone_b", "clone_c", "clone_a", "clone_c"])
+    distances = bp.clone_expression_distances(
+        expression, labels, ["clone_c", "clone_b", "clone_a"]
+    )
+    assert distances.shape == (3, 3)
+    assert np.allclose(distances, distances.T)
+    assert np.all(np.diag(distances) >= 0)
+    assert np.isfinite(distances).all()
+    with pytest.raises(ValueError, match="missing 1"):
+        bp.clone_expression_distances(expression, labels, ["missing"])
+
+
+def test_coupling_data_matches_direct_spearman_and_handles_empty_graph():
+    data = _small_plot_data()
+    expression = data.latent_distances * 2
+    embedding = data.latent_distances * 3
+    reduced, correlations = bp.coupling_data(
+        expression, data.latent_distances, embedding, data.network
+    )
+    assert len(reduced) == 4  # two undirected edges, retained as R-style directed entries
+    assert correlations == {"expression_latent": 1.0, "expression_embedding": 1.0}
+
+    empty = aa.BenisseNetworkResult(
+        node_ids=data.network.node_ids,
+        row=np.array([], dtype=np.int64), col=np.array([], dtype=np.int64),
+        weight=np.array([], dtype=float),
+    )
+    reduced, correlations = bp.coupling_data(
+        expression, data.latent_distances, embedding, empty
+    )
+    assert reduced.empty
+    assert np.isnan(correlations["expression_latent"])
+
+
+@pytest.mark.parametrize("color_by", ["clone_size", "vj_family", "graph_component"])
+def test_connection_plot_color_modes_render(color_by):
+    axis = bp.plot_embedding_network(_small_plot_data(), color_by=color_by)
+    assert axis.get_title() == "Benisse clonotype network"
+    assert len(axis.collections) >= 2
+    plt.close(axis.figure)
+
+
+def test_all_plot_types_write_nonempty_pdf(tmp_path):
+    data = _small_plot_data()
+    axes = [
+        bp.plot_embedding_network(data),
+        bp.plot_latent_distance_groups(data),
+        bp.plot_network_summary(data)[0],
+    ]
+    reduced, correlations = bp.coupling_data(
+        data.latent_distances * 2,
+        data.latent_distances,
+        data.latent_distances * 3,
+        data.network,
+    )
+    axes.append(bp.plot_coupling_correlation(reduced, correlations))
+    for index, axis in enumerate(axes):
+        path = tmp_path / f"plot_{index}.pdf"
+        axis.figure.savefig(path)
+        assert path.read_bytes().startswith(b"%PDF")
+        assert path.stat().st_size > 1_000
+        plt.close(axis.figure)
+
+
+def test_read_committed_example_plot_data():
+    data = bp.read_plot_data(EXAMPLE, encoded_csv=EXAMPLE / "encoded_10x_NSCLC.csv")
+    assert data.network.n_nodes == 1494
+    assert data.network.n_edges == 1691
+    assert data.annotation.shape[0] == 1494
+    assert data.embedding.shape == (1494, 20)
+    assert data.latent_distances.shape == (1494, 1494)
+    assert np.isfinite(bp.edge_retention_ratio(data))
+
+
+@pytest.mark.skipif(RSCRIPT is None, reason="Rscript is required for R post-analysis parity")
+def test_expression_distance_and_correlation_match_committed_r_oracle(tmp_path):
+    subprocess.run(
+        [
+            RSCRIPT,
+            str(ORACLE_R),
+            str(EXAMPLE / "Benisse_results.RData"),
+            str(EXAMPLE / "encoded_10x_NSCLC.csv"),
+            str(tmp_path),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        timeout=120,
+    )
+    data = bp.read_plot_data(EXAMPLE, encoded_csv=EXAMPLE / "encoded_10x_NSCLC.csv")
+    expression = bp.clone_expression_distances(
+        EXAMPLE / "cleaned_exp.txt",
+        EXAMPLE / "clonality_label.txt",
+        data.network.node_ids,
+    )
+    r_expression = np.loadtxt(tmp_path / "master_dist_e.txt")
+    r_candidate = np.loadtxt(tmp_path / "si.txt").astype(bool)
+    assert np.allclose(expression, r_expression, rtol=2e-6, atol=2e-8)
+    assert np.array_equal(bp.crude_graph(data.annotation), r_candidate)
+
+    _, correlations = bp.coupling_data(
+        expression,
+        data.latent_distances,
+        bp.bcr_embedding_distances(data.embedding),
+        data.network,
+    )
+    r_correlations = np.loadtxt(tmp_path / "correlations.txt")
+    assert correlations["expression_latent"] == pytest.approx(r_correlations[0], abs=2e-8)
+    assert correlations["expression_embedding"] == pytest.approx(r_correlations[1], abs=2e-8)


### PR DESCRIPTION
## Scope
- Add internal Python-native post-analysis and scientific plots over the shared `BenisseNetworkResult` contract.
- Keep the merged Phase 4c R bridge as the default numerical path; the plots work independently of which core produced the result.
- Preserve the committed R PDFs and write distinct `python_*.pdf` outputs.

## Scientific parity
- Reconstruct the V/J-family candidate graph and true graph components.
- Port the clone-level expression-distance calculation from `R/initiation.R`.
- Port `testCor` median aggregation and both Spearman coupling statistics, including R's directed-edge convention and final remainder-bin behavior.
- Validate the complete 1,494-node committed NSCLC expression-distance matrix against a live RData export (`rtol=2e-6`, `atol=2e-8`), exact candidate support, and both correlation values (`abs=2e-8`).
- Preserve the legacy nonzero diagonal of clone expression distances, which represents within-clone distances between distinct cells.

## Plots
- Clonotype network with learned edges and PCA, optional deterministic UMAP, or deterministic t-SNE coordinates.
- Node coloring by clone size, V/J family, or true graph component.
- Latent-distance distributions for learned edges, rejected V/J candidates, and non-candidates.
- Clone-size, component-size, and retained-candidate-edge diagnostics.
- Expression-versus-latent and expression-versus-encoder coupling scatter and statistics.

## Verification
- Focused Phase 2 suite: 11 passed in 32.94 seconds.
- Combined suite: 89 passed, 4 explicit local/slow skips in 41.39 seconds.
- Optional UMAP path executed successfully in the pinned Intel-macOS environment.
- Four full-example PDFs generated and raster-inspected.

Public plotting names, Scanpy conventions, CLI exposure, and packaging remain deferred to Phase 4e. Usage and parity decisions are recorded in `PHASE2_NOTES.md` and the living `UPDATE_PLAN.md`.
